### PR TITLE
Refactor: Locales and Improve handling servers when unblocking

### DIFF
--- a/ServerPickerX/Locales/Locale_de-de.axaml
+++ b/ServerPickerX/Locales/Locale_de-de.axaml
@@ -14,7 +14,15 @@
   <x:String x:Key="GameModeToolTip">Spielmodus auswählen</x:String>
   <x:String x:Key="ClusterUnclusterToolTip">Server gruppieren oder entgruppieren</x:String>
   <x:String x:Key="RefreshToolTip">Ping aller Server aktualisieren</x:String>
-  <x:String x:Key="UnblockAllConflict">Diese Aktion wird zuerst alle Server freigeben, um Firewall-Konflikte zu vermeiden.</x:String>
+  <x:String x:Key="SwapGameModeUnblockAllConflict">Diese Aktion wird zuerst alle Server freigeben, um Firewall-Konflikte zu vermeiden.</x:String>
   <x:String x:Key="LanguageComboBoxToolTip">Sprache auswählen</x:String>
   <x:String x:Key="ResetFirewallToolTip">Firewall-Regeln zurücksetzen</x:String>
+  <x:String x:Key="MessageBoxInfoTitle">Info</x:String>
+  <x:String x:Key="SyncServersUnblockAllDialogue">Die Serverdaten wurden soeben von Valve aktualisiert! Alle gesperrten Server werden entsperrt, um die neuen Serverdaten zu synchronisieren.</x:String>
+  <x:String x:Key="NewVersionDialogue">Neue Version verfügbar! Zu den Veröffentlichungen?</x:String>
+  <x:String x:Key="SelectOneServerToBlockDialogue">Hey! Bitte wähle mindestens einen Server zum Blockieren aus.</x:String>
+  <x:String x:Key="SelectOneServerToUnblockDialogue">Bitte wählen Sie mindestens einen Server aus, um die Entsperrung aufzuheben.</x:String>
+  <x:String x:Key="PendingOperationDialogue">Moment! Ein Vorgang läuft bereits. Bitte warten Sie...</x:String>
+  <x:String x:Key="FirewallResetConfirmDialogue">Dadurch wird versucht, die Firewall auf den Standardzustand zurückzusetzen. Aktion bestätigen?</x:String>
+  <x:String x:Key="FirewallResetSuccessDialogue">Firewall erfolgreich zurückgesetzt!</x:String>
 </ResourceDictionary>

--- a/ServerPickerX/Locales/Locale_en-us.axaml
+++ b/ServerPickerX/Locales/Locale_en-us.axaml
@@ -14,7 +14,15 @@
   <x:String x:Key="GameModeToolTip">Select game mode</x:String>
   <x:String x:Key="ClusterUnclusterToolTip">Group or ungroup servers</x:String>
   <x:String x:Key="RefreshToolTip">Refresh all server ping</x:String>
-  <x:String x:Key="UnblockAllConflict">This action will unblock all servers first to prevent firewall conflicts.</x:String>
+  <x:String x:Key="SwapGameModeUnblockAllConflict">This action will unblock all servers first to prevent firewall conflicts.</x:String>
   <x:String x:Key="LanguageComboBoxToolTip">Select language</x:String>
   <x:String x:Key="ResetFirewallToolTip">Reset firewall rules</x:String>
+  <x:String x:Key="MessageBoxInfoTitle">Info</x:String>
+  <x:String x:Key="SyncServersUnblockAllDialogue">Server data just got updated by Valve! All blocked servers will be unblocked in order to synchronize new server data</x:String>
+  <x:String x:Key="NewVersionDialogue">New version available! Go to releases?</x:String>
+  <x:String x:Key="SelectOneServerToBlockDialogue">Hey! Please select at least one server to block</x:String>
+  <x:String x:Key="SelectOneServerToUnblockDialogue">Hey! Please select at least one server to unblock</x:String>
+  <x:String x:Key="PendingOperationDialogue">Whoa! There's already a pending operation. Please wait...</x:String>
+  <x:String x:Key="FirewallResetConfirmDialogue">This will attempt to reset firewall to its default state. Confirm action?</x:String>
+  <x:String x:Key="FirewallResetSuccessDialogue">Firewall has been successfully reset!</x:String>
 </ResourceDictionary>

--- a/ServerPickerX/Locales/Locale_es-es.axaml
+++ b/ServerPickerX/Locales/Locale_es-es.axaml
@@ -14,7 +14,15 @@
   <x:String x:Key="GameModeToolTip">Seleccionar modo de juego</x:String>
   <x:String x:Key="ClusterUnclusterToolTip">Agrupar o desagrupar servidores</x:String>
   <x:String x:Key="RefreshToolTip">Actualizar el ping de todos los servidores</x:String>
-  <x:String x:Key="UnblockAllConflict">Esta acción desbloqueará primero todos los servidores para evitar conflictos de firewall.</x:String>
+  <x:String x:Key="SwapGameModeUnblockAllConflict">Esta acción desbloqueará primero todos los servidores para evitar conflictos de firewall.</x:String>
   <x:String x:Key="LanguageComboBoxToolTip">Seleccionar idioma</x:String>
   <x:String x:Key="ResetFirewallToolTip">Restablecer reglas del firewall</x:String>
+  <x:String x:Key="MessageBoxInfoTitle">Información</x:String>
+  <x:String x:Key="SyncServersUnblockAllDialogue">¡Valve acaba de actualizar los datos del servidor! Todos los servidores bloqueados serán desbloqueados para sincronizar los nuevos datos.</x:String>
+  <x:String x:Key="NewVersionDialogue">¡Nueva versión disponible! ¿Ir a lanzamientos?</x:String>
+  <x:String x:Key="SelectOneServerToBlockDialogue">Por favor, selecciona al menos un servidor para bloquear.</x:String>
+  <x:String x:Key="SelectOneServerToUnblockDialogue">Seleccione al menos un servidor para desbloquear.</x:String>
+  <x:String x:Key="PendingOperationDialogue">¡Vaya! Ya hay una operación pendiente. Por favor, espere...</x:String>
+  <x:String x:Key="FirewallResetConfirmDialogue">Esto intentará restablecer el cortafuegos a su estado predeterminado. ¿Confirma la acción?</x:String>
+  <x:String x:Key="FirewallResetSuccessDialogue">¡El cortafuegos se ha restablecido correctamente a su estado predeterminado!</x:String>
 </ResourceDictionary>

--- a/ServerPickerX/Locales/Locale_ja-jp.axaml
+++ b/ServerPickerX/Locales/Locale_ja-jp.axaml
@@ -14,7 +14,15 @@
   <x:String x:Key="GameModeToolTip">ゲームモードを選択</x:String>
   <x:String x:Key="ClusterUnclusterToolTip">サーバーをグループ化またはグループ解除</x:String>
   <x:String x:Key="RefreshToolTip">すべてのサーバーの ping を更新</x:String>
-  <x:String x:Key="UnblockAllConflict">この操作は、ファイアウォールの競合を防ぐためにまずすべてのサーバーを解除します。</x:String>
+  <x:String x:Key="SwapGameModeUnblockAllConflict">この操作は、ファイアウォールの競合を防ぐためにまずすべてのサーバーを解除します。</x:String>
   <x:String x:Key="LanguageComboBoxToolTip">言語を選択</x:String>
   <x:String x:Key="ResetFirewallToolTip">ファイアウォールルールをリセット</x:String>
+  <x:String x:Key="MessageBoxInfoTitle">情報</x:String>
+  <x:String x:Key="SyncServersUnblockAllDialogue">Valveによってサーバーデータが更新されました！新しいサーバーデータを同期するために、ブロックされていたすべてのサーバーのブロックが解除されます。</x:String>
+  <x:String x:Key="NewVersionDialogue">新バージョンがリリースされました！リリース一覧へどうぞ。</x:String>
+  <x:String x:Key="SelectOneServerToBlockDialogue">こんにちは！ブロックするサーバーを少なくとも1つ選択してください。</x:String>
+  <x:String x:Key="SelectOneServerToUnblockDialogue">ブロックを解除したいサーバーを少なくとも1つ選択してください。</x:String>
+  <x:String x:Key="PendingOperationDialogue">おっと！既に処理が実行されています。しばらくお待ちください。</x:String>
+  <x:String x:Key="FirewallResetConfirmDialogue">これにより、ファイアウォールがデフォルトの状態にリセットされます。操作を確定しますか？</x:String>
+  <x:String x:Key="FirewallResetSuccessDialogue">ファイアウォールが正常にリセットされました！</x:String>
 </ResourceDictionary>

--- a/ServerPickerX/Locales/Locale_pl-pl.axaml
+++ b/ServerPickerX/Locales/Locale_pl-pl.axaml
@@ -14,7 +14,15 @@
   <x:String x:Key="GameModeToolTip">Wybierz Tryb gry</x:String>
   <x:String x:Key="ClusterUnclusterToolTip">Grupowanie lub rozgrupowywanie serwerów</x:String>
   <x:String x:Key="RefreshToolTip">Odśwież ping wszystkich serwerów</x:String>
-  <x:String x:Key="UnblockAllConflict">Ta czynność odblokuje najpierw wszystkie serwery, aby zapobiec konfliktom z zaporą sieciową.</x:String>
+  <x:String x:Key="SwapGameModeUnblockAllConflict">Ta czynność odblokuje najpierw wszystkie serwery, aby zapobiec konfliktom z zaporą sieciową.</x:String>
   <x:String x:Key="LanguageComboBoxToolTip">Wybierz język</x:String>
   <x:String x:Key="ResetFirewallToolTip">Zresetuj reguły zapory sieciowej</x:String>
+  <x:String x:Key="MessageBoxInfoTitle">informacje</x:String>
+  <x:String x:Key="SyncServersUnblockAllDialogue">Valve właśnie zaktualizowało dane serwera! Wszystkie zablokowane serwery zostaną odblokowane, aby zsynchronizować nowe dane serwera.</x:String>
+  <x:String x:Key="NewVersionDialogue">Nowa wersja dostępna! Przejdź do wydań?</x:String>
+  <x:String x:Key="SelectOneServerToBlockDialogue">Hej! Wybierz co najmniej jeden serwer do zablokowania</x:String>
+  <x:String x:Key="SelectOneServerToUnblockDialogue">Hej! Wybierz co najmniej jeden serwer do odblokowania</x:String>
+  <x:String x:Key="PendingOperationDialogue">Ojej! Jest już operacja w toku. Proszę czekać...</x:String>
+  <x:String x:Key="FirewallResetConfirmDialogue">Spowoduje to próbę przywrócenia zapory do stanu domyślnego. Czy potwierdzić działanie?</x:String>
+  <x:String x:Key="FirewallResetSuccessDialogue">Zapora sieciowa została pomyślnie zresetowana!</x:String>
 </ResourceDictionary>

--- a/ServerPickerX/Locales/Locale_ru-ru.axaml
+++ b/ServerPickerX/Locales/Locale_ru-ru.axaml
@@ -14,7 +14,15 @@
   <x:String x:Key="GameModeToolTip">Выберите режим игры</x:String>
   <x:String x:Key="ClusterUnclusterToolTip">Группировать или разгруппировать серверы</x:String>
   <x:String x:Key="RefreshToolTip">Обновить пинг всех серверов</x:String>
-  <x:String x:Key="UnblockAllConflict">Это действие сначала разблокирует все сервера для предотвращения конфликтов брандмауэра.</x:String>
+  <x:String x:Key="SwapGameModeUnblockAllConflict">Это действие сначала разблокирует все сервера для предотвращения конфликтов брандмауэра.</x:String>
   <x:String x:Key="LanguageComboBoxToolTip">Выберите язык</x:String>
   <x:String x:Key="ResetFirewallToolTip">Сбросить правила брандмауэра</x:String>
+  <x:String x:Key="MessageBoxInfoTitle">информация</x:String>
+  <x:String x:Key="SyncServersUnblockAllDialogue">Valve обновила данные серверов! Все заблокированные серверы будут разблокированы для синхронизации новых данных.</x:String>
+  <x:String x:Key="NewVersionDialogue">Доступна новая версия! Перейти к релизам?</x:String>
+  <x:String x:Key="SelectOneServerToBlockDialogue">Пожалуйста, выберите хотя бы один сервер для блокировки.</x:String>
+  <x:String x:Key="SelectOneServerToUnblockDialogue">Пожалуйста, выберите хотя бы один сервер для разблокировки.</x:String>
+  <x:String x:Key="PendingOperationDialogue">Ого! Уже есть ожидающая операция. Пожалуйста, подождите...</x:String>
+  <x:String x:Key="FirewallResetConfirmDialogue">Это попытается сбросить брандмауэр до состояния по умолчанию. Подтвердите действие?</x:String>
+  <x:String x:Key="FirewallResetSuccessDialogue">Межсетевой экран успешно перезагружен и вернулся в состояние по умолчанию!</x:String>
 </ResourceDictionary>

--- a/ServerPickerX/Locales/Locale_sv-se.axaml
+++ b/ServerPickerX/Locales/Locale_sv-se.axaml
@@ -14,7 +14,15 @@
   <x:String x:Key="GameModeToolTip">Välj spelläge</x:String>
   <x:String x:Key="ClusterUnclusterToolTip">Gruppera eller avgruppera servrar</x:String>
   <x:String x:Key="RefreshToolTip">Uppdatera ping för alla servrar</x:String>
-  <x:String x:Key="UnblockAllConflict">Detta åtgärder kommer att avblockera alla servrar först för att undvika brandvägskonflikter.</x:String>
+  <x:String x:Key="SwapGameModeUnblockAllConflict">Detta åtgärder kommer att avblockera alla servrar först för att undvika brandvägskonflikter.</x:String>
   <x:String x:Key="LanguageComboBoxToolTip">Välj språk</x:String>
   <x:String x:Key="ResetFirewallToolTip">Återställ brandväggsregler</x:String>
+  <x:String x:Key="MessageBoxInfoTitle">info</x:String>
+  <x:String x:Key="SyncServersUnblockAllDialogue">Serverdata har precis uppdaterats av Valve! Alla blockerade servrar kommer att avblockeras för att synkronisera ny serverdata.</x:String>
+  <x:String x:Key="NewVersionDialogue">Ny version tillgänglig! Gå till utgåvor?</x:String>
+  <x:String x:Key="SelectOneServerToBlockDialogue">Välj minst en server att blockera</x:String>
+  <x:String x:Key="SelectOneServerToUnblockDialogue">Välj minst en server att avblockera.</x:String>
+  <x:String x:Key="PendingOperationDialogue">Oj! Det finns redan en väntande åtgärd. Vänta...</x:String>
+  <x:String x:Key="FirewallResetConfirmDialogue">Detta kommer att försöka återställa brandväggen till standardläget. Bekräfta åtgärd?</x:String>
+  <x:String x:Key="FirewallResetSuccessDialogue">Brandväggen har återställts!</x:String>
 </ResourceDictionary>

--- a/ServerPickerX/Locales/Locale_zh-cn.axaml
+++ b/ServerPickerX/Locales/Locale_zh-cn.axaml
@@ -14,7 +14,15 @@
   <x:String x:Key="GameModeToolTip">选择游戏模式</x:String>
   <x:String x:Key="ClusterUnclusterToolTip">分组或取消分组服务器</x:String>
   <x:String x:Key="RefreshToolTip">刷新所有服务器 ping</x:String>
-  <x:String x:Key="UnblockAllConflict">此操作将首先解除所有服务器的阻止，以防止防火墙冲突。</x:String>
+  <x:String x:Key="SwapGameModeUnblockAllConflict">此操作将首先解除所有服务器的阻止，以防止防火墙冲突。</x:String>
   <x:String x:Key="LanguageComboBoxToolTip">选择语言</x:String>
   <x:String x:Key="ResetFirewallToolTip">重置防火墙规则</x:String>
+  <x:String x:Key="MessageBoxInfoTitle">信息</x:String>
+  <x:String x:Key="SyncServersUnblockAllDialogue">Valve刚刚更新了服务器数据！所有被屏蔽的服务器都将被解除屏蔽，以便同步新的服务器数据。</x:String>
+  <x:String x:Key="NewVersionDialogue">新版本已发布！前往发布页面？</x:String>
+  <x:String x:Key="SelectOneServerToBlockDialogue">嘿！请至少选择一个服务器进行屏蔽。</x:String>
+  <x:String x:Key="SelectOneServerToUnblockDialogue">嘿！请至少选择一个服务器进行解锁。</x:String>
+  <x:String x:Key="PendingOperationDialogue">目前有待处理的操作。请稍候……</x:String>
+  <x:String x:Key="FirewallResetConfirmDialogue">此操作将尝试把防火墙重置为默认状态。确认操作？</x:String>
+  <x:String x:Key="FirewallResetSuccessDialogue">防火墙已成功重置！</x:String>
 </ResourceDictionary>

--- a/ServerPickerX/ServerPickerX.csproj
+++ b/ServerPickerX/ServerPickerX.csproj
@@ -20,6 +20,8 @@
         <PackageProjectUrl>https://github.com/FN-FAL113/server-picker-x</PackageProjectUrl>
         <RepositoryUrl>https://github.com/FN-FAL113/server-picker-x</RepositoryUrl>
         <ApplicationIcon>Assets\favicon.ico</ApplicationIcon>
+        <AssemblyVersion>1.0.1.0</AssemblyVersion>
+        <FileVersion>1.0.1.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ServerPickerX/Services/SystemFirewalls/LinuxFirewallService.cs
+++ b/ServerPickerX/Services/SystemFirewalls/LinuxFirewallService.cs
@@ -1,4 +1,5 @@
 using ServerPickerX.Models;
+using ServerPickerX.Services.Localizations;
 using ServerPickerX.Services.Loggers;
 using ServerPickerX.Services.MessageBoxes;
 using ServerPickerX.Services.Processes;
@@ -12,6 +13,7 @@ namespace ServerPickerX.Services.SystemFirewalls
 {
     public class LinuxFirewallService(
         ILoggerService _loggerService,
+        ILocalizationService _localizationService,
         IMessageBoxService _messageBoxService,
         IProcessService _processService
         ) : ISystemFirewallService
@@ -32,19 +34,17 @@ namespace ServerPickerX.Services.SystemFirewalls
                     process.Start();
                     await process.WaitForExitAsync();
 
-                    string stdOut = process.StandardOutput.ReadToEnd();
-                    string stdErr = process.StandardError.ReadToEnd();
+                    string stdOut = process.StandardOutput.ReadToEnd().Trim();
+                    string stdErr = process.StandardError.ReadToEnd().Trim();
 
-                    if ((process.ExitCode == 1 || process.ExitCode < 0) &&
-                        !($"{stdOut} {stdErr}".Contains("Bad rule (does a matching")))
+                    if (process.ExitCode > 0)
                     {
-                        throw new Exception("StdOut: " + stdOut + Environment.NewLine + "StdErr: " + stdErr);
+                        await _loggerService.LogWarningAsync("StdOut: " + stdOut + " StdErr: " + stdErr);
                     }
                 }
                 catch (Exception ex)
                 {
-                    await _loggerService.LogErrorAsync($"Failed to block server {serverModel.Name}", ex.Message);
-
+                    // Perform debugging here if necessary (log error or through debugger breakpoints)
                     throw;
                 }
             }
@@ -66,19 +66,17 @@ namespace ServerPickerX.Services.SystemFirewalls
                     process.Start();
                     await process.WaitForExitAsync();
 
-                    string stdOut = process.StandardOutput.ReadToEnd();
-                    string stdErr = process.StandardError.ReadToEnd();
+                    string stdOut = process.StandardOutput.ReadToEnd().Trim();
+                    string stdErr = process.StandardError.ReadToEnd().Trim();
 
-                    if ((process.ExitCode == 1 || process.ExitCode < 0) &&
-                        !($"{stdOut} {stdErr}".Contains("Bad rule (does a matching")))
+                    if (process.ExitCode > 0)
                     {
-                        throw new Exception("StdOut: " + stdOut + Environment.NewLine + "StdErr: " + stdErr);
+                        await _loggerService.LogWarningAsync("StdOut: " + stdOut + " StdErr: " + stdErr);
                     }
                 }
                 catch (Exception ex)
                 {
-                    await _loggerService.LogErrorAsync($"Failed to unblock server {serverModel.Name}", ex.Message);
-
+                    // Perform debugging here if necessary (log error or through debugger breakpoints)
                     throw;
                 }
             }
@@ -87,8 +85,8 @@ namespace ServerPickerX.Services.SystemFirewalls
         public async Task ResetFirewallAsync()
         {
             var result = await _messageBoxService.ShowMessageBoxConfirmationAsync(
-                "Warning",
-                "This will attempt to reset firewall to its default state. Confirm action?",
+                _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                _localizationService.GetLocaleValue("FirewallResetConfirmDialogue"),
                 MsBox.Avalonia.Enums.Icon.Warning
                 );
 
@@ -106,26 +104,24 @@ namespace ServerPickerX.Services.SystemFirewalls
                 process.Start();
                 process.WaitForExit();
 
-                if (process.ExitCode == 1 || process.ExitCode < 0)
+                string stdOut = process.StandardOutput.ReadToEnd().Trim();
+                string stdErr = process.StandardError.ReadToEnd().Trim();
+
+                if (process.ExitCode > 0)
                 {
-                    throw new Exception("StdOut: " + process.StandardOutput.ReadToEnd() +
-                        Environment.NewLine + "StdErr: " + process.StandardError.ReadToEnd());
+                    await _loggerService.LogWarningAsync("StdOut: " + stdOut + " StdErr: " + stdErr);
                 }
 
                 await _messageBoxService.ShowMessageBoxAsync(
-                    "Info",
-                    "Successfully reset iptables!",
+                    _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                    _localizationService.GetLocaleValue("FirewallResetSuccessDialogue"),
                     MsBox.Avalonia.Enums.Icon.Success
                     );
             }
             catch (Exception ex)
             {
-                await _loggerService.LogErrorAsync("An error has occured while resetting iptables.", ex.Message);
-
-                await _messageBoxService.ShowMessageBoxAsync(
-                    "Error",
-                    "An error has occured while resetting firewall! Please upload log file to github."
-                    );
+                // Perform debugging here if necessary (log error or through debugger breakpoints)
+                throw;
             }
         }
     }

--- a/ServerPickerX/Services/SystemFirewalls/WindowsFirewallService.cs
+++ b/ServerPickerX/Services/SystemFirewalls/WindowsFirewallService.cs
@@ -1,5 +1,6 @@
 using Avalonia.Logging;
 using ServerPickerX.Models;
+using ServerPickerX.Services.Localizations;
 using ServerPickerX.Services.Loggers;
 using ServerPickerX.Services.MessageBoxes;
 using ServerPickerX.Services.Processes;
@@ -14,6 +15,7 @@ namespace ServerPickerX.Services.SystemFirewalls
 {
     public class WindowsFirewallService(
         ILoggerService _loggerService,
+        ILocalizationService _localizationService,
         IMessageBoxService _messageBoxService,
         IProcessService _processService
         ) : ISystemFirewallService
@@ -37,19 +39,17 @@ namespace ServerPickerX.Services.SystemFirewalls
                     process.Start();
                     await process.WaitForExitAsync();
 
-                    string stdOut = process.StandardOutput.ReadToEnd();
-                    string stdErr = process.StandardError.ReadToEnd();
+                    string stdOut = process.StandardOutput.ReadToEnd().Trim();
+                    string stdErr = process.StandardError.ReadToEnd().Trim();
 
-                    if ((process.ExitCode == 1 || process.ExitCode < 0) &&
-                        !($"{stdOut} {stdErr}".Contains("No rules match")))
+                    if (process.ExitCode > 0)
                     {
-                        throw new Exception("StdOut: " + stdOut + Environment.NewLine + "StdErr: " + stdErr);
+                        await _loggerService.LogWarningAsync("StdOut: " + stdOut + " StdErr: " + stdErr);
                     }
                 }
                 catch (Exception ex)
                 {
-                    await _loggerService.LogErrorAsync($"Failed to block server {serverModel.Name}", ex.Message);
-
+                    // Perform debugging here if necessary (log error or through debugger breakpoints)
                     throw;
                 }
             }
@@ -73,19 +73,17 @@ namespace ServerPickerX.Services.SystemFirewalls
                     process.Start();
                     await process.WaitForExitAsync();
 
-                    string stdOut = process.StandardOutput.ReadToEnd();
-                    string stdErr = process.StandardError.ReadToEnd();
+                    string stdOut = process.StandardOutput.ReadToEnd().Trim();
+                    string stdErr = process.StandardError.ReadToEnd().Trim();
 
-                    if ((process.ExitCode == 1 || process.ExitCode < 0) &&
-                        !($"{stdOut} {stdErr}".Contains("No rules match")))
+                    if (process.ExitCode > 0)
                     {
-                        throw new Exception("StdOut: " + stdOut + Environment.NewLine + "StdErr: " + stdErr);
+                        await _loggerService.LogWarningAsync("StdOut: " + stdOut + " StdErr: " + stdErr);
                     }
                 }
                 catch (Exception ex)
                 {
-                    await _loggerService.LogErrorAsync($"Failed to unblock server {serverModel.Name}", ex.Message);
-
+                    // Perform debugging here if necessary (log error or through debugger breakpoints)
                     throw;
                 }
             }
@@ -94,8 +92,8 @@ namespace ServerPickerX.Services.SystemFirewalls
         public async Task ResetFirewallAsync()
         {
             var result = await _messageBoxService.ShowMessageBoxConfirmationAsync(
-                    "Warning",
-                    "This will attempt to reset firewall to its default state. Confirm action?",
+                    _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                    _localizationService.GetLocaleValue("FirewallResetConfirmDialogue"),
                     MsBox.Avalonia.Enums.Icon.Warning
                 );
 
@@ -113,26 +111,24 @@ namespace ServerPickerX.Services.SystemFirewalls
                 process.Start();
                 process.WaitForExit();
 
-                if (process.ExitCode == 1 || process.ExitCode < 0)
+                string stdOut = process.StandardOutput.ReadToEnd().Trim();
+                string stdErr = process.StandardError.ReadToEnd().Trim();
+
+                if (process.ExitCode > 0)
                 {
-                    throw new Exception("StdOut: " + process.StandardOutput.ReadToEnd() +
-                        Environment.NewLine + "StdErr: " + process.StandardError.ReadToEnd());
+                    await _loggerService.LogWarningAsync("StdOut: " + stdOut + " StdErr: " + stdErr);
                 }
 
                 await _messageBoxService.ShowMessageBoxAsync(
-                    "Info",
-                    "Successfully reset windows firewall!",
+                    _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                    _localizationService.GetLocaleValue("FirewallResetSuccessDialogue"),
                     MsBox.Avalonia.Enums.Icon.Success
                     );
             }
             catch (Exception ex)
             {
-                await _loggerService.LogErrorAsync("An error has occured while resetting firewall.", ex.Message);
-
-                await _messageBoxService.ShowMessageBoxAsync(
-                    "Error",
-                    "An error has occured while resetting windows firewall! Please upload log file to github."
-                    );
+                // Perform debugging here if necessary (log error or through debugger breakpoints)
+                throw;
             }
         }
     }

--- a/ServerPickerX/Services/Versions/VersionService.cs
+++ b/ServerPickerX/Services/Versions/VersionService.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using ServerPickerX.Services.MessageBoxes;
 using ServerPickerX.Services.Loggers;
+using ServerPickerX.Services.Localizations;
 
 namespace ServerPickerX.Services.Versions
 {
@@ -16,18 +17,21 @@ namespace ServerPickerX.Services.Versions
     {
         private readonly ILoggerService _logger;
         private readonly IMessageBoxService _messageBoxService;
+        private readonly ILocalizationService _localizationService;
         private readonly HttpClient _httpClient;
         private readonly JsonSetting _jsonSettings;
 
         public VersionService(
             ILoggerService logger,
             IMessageBoxService messageBoxService,
+            ILocalizationService localizationService,
             HttpClient httpClient,
             JsonSetting jsonSettings
             )
         {
             _logger = logger;
             _messageBoxService = messageBoxService;
+            _localizationService = localizationService;
             _httpClient = httpClient;
             _jsonSettings = jsonSettings;
         }
@@ -71,8 +75,8 @@ namespace ServerPickerX.Services.Versions
 
                 // prompt user to visit gh releases page for newer version
                 await _messageBoxService.ShowMessageBoxWithLinkAsync(
-                        "Version Check",
-                        "New version available! Go to releases?",
+                        _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                        _localizationService.GetLocaleValue("NewVersionDialogue"),
                         "https://github.com/FN-FAL113/server-picker-x/releases"
                     );
             }

--- a/ServerPickerX/ViewModels/MainWindowViewModel.cs
+++ b/ServerPickerX/ViewModels/MainWindowViewModel.cs
@@ -4,6 +4,7 @@ using MsBox.Avalonia.Enums;
 using ServerPickerX.Extensions;
 using ServerPickerX.Models;
 using ServerPickerX.Services.DependencyInjection;
+using ServerPickerX.Services.Localizations;
 using ServerPickerX.Services.Loggers;
 using ServerPickerX.Services.MessageBoxes;
 using ServerPickerX.Services.Servers;
@@ -22,7 +23,7 @@ namespace ServerPickerX.ViewModels
     {
         public ObservableCollectionExtended<ServerModel> ServerModels { get; set; } = [];
 
-        // Property resolve through expression body that react to changes from another observable property
+        // Property resolved through expression body that react to changes from another observable property
         public ObservableCollectionExtended<ServerModel> FilteredServerModels =>
              string.IsNullOrWhiteSpace(SearchText)
                 ? ServerModels
@@ -34,7 +35,7 @@ namespace ServerPickerX.ViewModels
         public ServerModel? SelectedDataGridServerModel { get; set; }
 
         // Mvvm tool kit will auto generate source code to make this property observable
-        // When updating this property, reference it by its auto property name (PascalCase)
+        // When updating a data binding property, reference by its auto property name (PascalCase)
         [ObservableProperty]
         public bool showProgressBar = false;
 
@@ -58,6 +59,7 @@ namespace ServerPickerX.ViewModels
 
         private readonly ILoggerService _loggerService;
         private readonly IMessageBoxService _messageBoxService;
+        private readonly ILocalizationService _localizationService;
         private readonly IServerDataService _serverDataService;
         private readonly ISystemFirewallService _systemFirewallService;
         private readonly JsonSetting _jsonSetting;
@@ -67,6 +69,7 @@ namespace ServerPickerX.ViewModels
         {
             _loggerService = ServiceLocator.GetRequiredService<ILoggerService>();
             _messageBoxService = ServiceLocator.GetRequiredService<IMessageBoxService>();
+            _localizationService = ServiceLocator.GetRequiredService<ILocalizationService>();
             _serverDataService = ServiceLocator.GetRequiredService<IServerDataService>();
             _systemFirewallService = ServiceLocator.GetRequiredService<ISystemFirewallService>();
             _jsonSetting = ServiceLocator.GetRequiredService<JsonSetting>();
@@ -76,6 +79,7 @@ namespace ServerPickerX.ViewModels
         public MainWindowViewModel(
             ILoggerService loggerService,
             IMessageBoxService messageBoxService,
+            ILocalizationService localizationService,
             IServerDataService serverDataService,
             ISystemFirewallService systemFirewallService,
             JsonSetting jsonSetting
@@ -83,6 +87,7 @@ namespace ServerPickerX.ViewModels
         {
             _loggerService = loggerService;
             _messageBoxService = messageBoxService;
+            _localizationService = localizationService;
             _serverDataService = serverDataService;
             _systemFirewallService = systemFirewallService;
             _jsonSetting = jsonSetting;
@@ -173,7 +178,10 @@ namespace ServerPickerX.ViewModels
         {
             if (selectedServers.Count == 0)
             {
-                await _messageBoxService.ShowMessageBoxAsync("Info", "Hey! Please select at least one server to block");
+                await _messageBoxService.ShowMessageBoxAsync(
+                    _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                    _localizationService.GetLocaleValue("SelectOneServerToBlockDialogue")
+                    );
 
                 return false;
             }
@@ -200,7 +208,10 @@ namespace ServerPickerX.ViewModels
         {
             if (selectedServers.Count == 0)
             {
-                await _messageBoxService.ShowMessageBoxAsync("Info", "Hey! Please select at least one server to unblock");
+                await _messageBoxService.ShowMessageBoxAsync(
+                    _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                    _localizationService.GetLocaleValue("SelectOneServerToUnblockDialogue")
+                    );
 
                 return false;
             }
@@ -215,8 +226,8 @@ namespace ServerPickerX.ViewModels
             if (PendingOperation)
             {
                 await _messageBoxService.ShowMessageBoxAsync(
-                    "Info",
-                    "Whoa! There's already a pending operation. Please wait...",
+                    _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                    _localizationService.GetLocaleValue("PendingOperationDialogue"),
                     Icon.Setting
                     );
 

--- a/ServerPickerX/ViewModels/SettingsWindowViewModel.cs
+++ b/ServerPickerX/ViewModels/SettingsWindowViewModel.cs
@@ -5,6 +5,7 @@ using ServerPickerX.Services.MessageBoxes;
 using ServerPickerX.Services.Servers;
 using ServerPickerX.Services.SystemFirewalls;
 using ServerPickerX.Settings;
+using System;
 using System.Threading.Tasks;
 
 namespace ServerPickerX.ViewModels
@@ -13,13 +14,17 @@ namespace ServerPickerX.ViewModels
     {
         public bool VersionCheckOnStartup { get; set; }
 
+        private readonly ILoggerService _loggerService;
+        private readonly IMessageBoxService _messageBoxService;
         private readonly ISystemFirewallService _systemFirewallService;
         private readonly JsonSetting _jsonSetting;
 
         // Parameterless constructor, allows design previewer to instantiate this class since it doesn't support DI
         public SettingsWindowViewModel()
         {
-_systemFirewallService = ServiceLocator.GetRequiredService<ISystemFirewallService>();
+            _loggerService = ServiceLocator.GetRequiredService<ILoggerService>();
+            _messageBoxService = ServiceLocator.GetRequiredService<IMessageBoxService>();
+            _systemFirewallService = ServiceLocator.GetRequiredService<ISystemFirewallService>();
             _jsonSetting = ServiceLocator.GetRequiredService<JsonSetting>();
 
             VersionCheckOnStartup = _jsonSetting.version_check_on_startup;
@@ -27,10 +32,14 @@ _systemFirewallService = ServiceLocator.GetRequiredService<ISystemFirewallServic
 
         // DI constructor, allows inversion of control and unit tests mocking
         public SettingsWindowViewModel(
+            ILoggerService loggerService,
+            IMessageBoxService messageBoxService,
             ISystemFirewallService systemFirewallService,
             JsonSetting jsonSetting
             )
         {
+            _loggerService = loggerService;
+            _messageBoxService = messageBoxService;
             _systemFirewallService = systemFirewallService;
             _jsonSetting = jsonSetting;
 
@@ -47,7 +56,20 @@ _systemFirewallService = ServiceLocator.GetRequiredService<ISystemFirewallServic
 
         public async Task ResetFirewallCommand()
         {
-            await _systemFirewallService.ResetFirewallAsync();
+            try
+            {
+                await _systemFirewallService.ResetFirewallAsync();
+            }
+            catch (Exception ex)
+            {
+                await _loggerService.LogErrorAsync("An error has occurred while resetting firewall.", ex.Message);
+
+                await _messageBoxService.ShowMessageBoxAsync(
+                    "Error",
+                    "Oops! Something went wrong. Please upload the log file to GitHub."
+                    );
+
+            }
         }
     }
 }

--- a/ServerPickerX/Views/MainWindow.axaml.cs
+++ b/ServerPickerX/Views/MainWindow.axaml.cs
@@ -85,8 +85,12 @@ namespace ServerPickerX.Views
         private async void DataGrid_DoubleTapped(object? sender, Avalonia.Input.TappedEventArgs e)
         {
             var source = e.Source;
-            if (source is Border || source is TextBlock || source is Image)
-                (DataContext as MainWindowViewModel)?.PingSelectedServer();
+
+            if (source is  Border or TextBlock or Image)
+            {
+                var vm = DataContext as MainWindowViewModel;
+                vm?.PingSelectedServer();
+            }
         }
 
         private void TitleBar_PointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
@@ -101,12 +105,19 @@ namespace ServerPickerX.Views
             pingSortDirection = pingSortDirection == ListSortDirection.Ascending
                 ? ListSortDirection.Descending
                 : ListSortDirection.Ascending;
+
             ServerList.Columns[3].CustomSortComparer = new PingComparer(pingSortDirection);
         }
 
         private async void ClusterUnclusterBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
-            if (!((DataContext as MainWindowViewModel)?.ServerModelsInitialized ?? false)) return;
+            var vm = DataContext as MainWindowViewModel;
+
+            // Check if servers are loaded and initialized
+            if (!vm?.ServerModelsInitialized ?? false)
+            {
+                return;
+            }
 
             // Update button DynamicResource binding base on language setting
             ClusterUnclusterBtn.Bind(
@@ -129,6 +140,7 @@ namespace ServerPickerX.Views
 
             DataContext = vm;
 
+           
             if (vm.ServersLoaded)
             {
                 await SyncServersAsync(vm);
@@ -139,7 +151,7 @@ namespace ServerPickerX.Views
 
         private void SetLanguage()
         {
-            // Extract language code
+            // Extract language code from enum text
             var language = _jsonSetting.language.Replace(" ", "").Split("|")[1];
 
             _localizationService.SetLanguage(language);
@@ -149,7 +161,7 @@ namespace ServerPickerX.Views
         {
             bool isGameModeCS2 = _jsonSetting.game_mode == GameModes.CounterStrike2;
 
-            // Update game mode combo box selection base on json settings
+            // Swap game mode combo box selection based on json settings
             GameModeComboBox.SelectedIndex = isGameModeCS2 ? 0 : 1;
 
             // Update button DynamicResource binding base on language setting
@@ -161,9 +173,9 @@ namespace ServerPickerX.Views
 
         private async Task SyncServersAsync(MainWindowViewModel vm)
         {
-            var localRevision = _jsonSetting.game_mode == GameModes.CounterStrike2
-                ? _jsonSetting.cs2_server_revision
-                : _jsonSetting.deadlock_server_revision;
+            // If Steam SDR API data got updated, sync the changes
+            var localRevision = _jsonSetting.game_mode == GameModes.CounterStrike2 ? 
+                _jsonSetting.cs2_server_revision : _jsonSetting.deadlock_server_revision;
 
             var fetchedRevision = vm.GetServerDataService().GetServerData().Revision;
 
@@ -174,10 +186,8 @@ namespace ServerPickerX.Views
             }
 
             await _messageBoxService.ShowMessageBoxAsync(
-                    "Please Standby",
-                    "Server data just got updated by Valve! All blocked servers "
-                    + Environment.NewLine +
-                    "will be unblocked in order to synchronize new server data",
+                    _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                    _localizationService.GetLocaleValue("SyncServersUnblockAllDialogue"),
                     MsBox.Avalonia.Enums.Icon.Setting
                     );
 
@@ -193,17 +203,20 @@ namespace ServerPickerX.Views
 
         private async Task HandleGameModeChangeAsync()
         {
-            if (DataContext is not MainWindowViewModel vm || GameModeComboBox.SelectedItem == null) return;
+            if (DataContext is not MainWindowViewModel vm || GameModeComboBox?.SelectedItem == null)
+            {
+                return;
+            }
 
             bool result = await _messageBoxService.ShowMessageBoxConfirmationAsync(
-                    "Info",
-                    _localizationService.GetLocaleValue("UnblockAllConflict"),
+                    _localizationService.GetLocaleValue("MessageBoxInfoTitle"),
+                    _localizationService.GetLocaleValue("SwapGameModeUnblockAllConflict"),
                     MsBox.Avalonia.Enums.Icon.Setting
                     );
 
             if (!result || vm.PendingOperation)
             {
-                // Revert back selection without triggering the handler
+                // Revert back selection without triggering event handler
                 GameModeComboBox.SelectionChanged -= GameModeComboBox_SelectionChanged;
                 GameModeComboBox.SelectedItem = _jsonSetting.game_mode;
                 GameModeComboBox.SelectionChanged += GameModeComboBox_SelectionChanged;


### PR DESCRIPTION
### Changes
- Add new localization keys across all locale files and rename UnblockAllConflict to SwapGameModeUnblockAllConflict.
- Inject and use ILocalizationService in firewall service, version service and viewmodel to replace hardcoded message strings with localized values.
- Trim process output, change non-zero exit handling to log warnings instead of throwing raw exceptions, and simplify exception handling in firewall service classes when no rules exist when unblocking servers (resolves #4).
- Update SettingsWindowViewModel to handle ResetFirewall errors and show an error dialog.
- Apply small UI/VM refactors and null-check improvements in MainWindow and MainWindowViewModel.
- Bump AssemblyVersion and FileVersion to 1.0.1.0 in the csproj.