### PR TITLE
feat: blocked firewall column

### DIFF
--- a/ServerPickerX.Tests/ServerPickerX.Tests.csproj
+++ b/ServerPickerX.Tests/ServerPickerX.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/ServerPickerX.Tests/SystemFirewalls/FirewallStateParsersTest.cs
+++ b/ServerPickerX.Tests/SystemFirewalls/FirewallStateParsersTest.cs
@@ -1,0 +1,64 @@
+using ServerPickerX.Models;
+using ServerPickerX.Services.SystemFirewalls;
+using Xunit;
+
+namespace ServerPickerX.Tests.SystemFirewalls
+{
+    public class FirewallStateParsersTest
+    {
+        [Fact]
+        public void WindowsFirewallRuleName_ForServer_MatchesNetshNaming()
+        {
+            var server = new ServerModel { Description = "New York" };
+
+            Assert.Equal("server_picker_x_NewYork", WindowsFirewallRuleName.ForServer(server));
+        }
+
+        [Fact]
+        public void NetshAdvFirewallRuleNameParser_CollectsNamesAfterRuleNamePrefix()
+        {
+            const string stdout = """
+                Rule Name:                            server_picker_x_Tokyo
+                ----------------------------------------------------------------------
+                Enabled:                              Yes
+
+                Rule Name:                            server_picker_x_NewYork
+                ----------------------------------------------------------------------
+                Enabled:                              Yes
+
+                """;
+
+            var names = NetshAdvFirewallRuleNameParser.ParseRuleNames(stdout);
+
+            Assert.Contains("server_picker_x_Tokyo", names);
+            Assert.Contains("server_picker_x_NewYork", names);
+        }
+
+        [Fact]
+        public void IptablesInputDropParser_BuildsIpSetsForDropRules()
+        {
+            const string stdout = """
+                -P INPUT ACCEPT
+                -A INPUT -s 10.0.0.1,10.0.0.2 -j DROP
+                -A INPUT -s 192.168.1.1/32 -j DROP
+                """;
+
+            var sets = IptablesInputDropParser.ParseDropSourceIpSets(stdout);
+
+            Assert.Equal(2, sets.Count);
+            Assert.Contains("10.0.0.1", sets[0]);
+            Assert.Contains("10.0.0.2", sets[0]);
+            Assert.Contains("192.168.1.1", sets[1]);
+        }
+
+        [Fact]
+        public void IptablesInputDropParser_IgnoresNonDropRules()
+        {
+            const string stdout = "-A INPUT -s 1.1.1.1 -j ACCEPT";
+
+            var sets = IptablesInputDropParser.ParseDropSourceIpSets(stdout);
+
+            Assert.Empty(sets);
+        }
+    }
+}

--- a/ServerPickerX.Tests/ViewModels/MainWindowViewModelTest.cs
+++ b/ServerPickerX.Tests/ViewModels/MainWindowViewModelTest.cs
@@ -8,6 +8,7 @@ using ServerPickerX.ViewModels;
 using ServerPickerX.Factories.Models;
 using MsBox.Avalonia.Enums;
 using System.Reflection;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using ServerPickerX.Models;
 using ServerPickerX.Services.Localizations;
@@ -33,6 +34,10 @@ namespace ServerPickerX.Tests.ViewModels
             _serverDataService = new Mock<IServerDataService>();
             _systemFirewallService = new Mock<ISystemFirewallService>();
             _jsonSetting = new Mock<JsonSetting>();
+
+            _systemFirewallService
+                .Setup(s => s.SyncBlockedStateAsync(It.IsAny<IReadOnlyList<ServerModel>>()))
+                .Returns(Task.CompletedTask);
 
             _vm = new MainWindowViewModel(
                 _loggerService.Object,
@@ -140,12 +145,11 @@ namespace ServerPickerX.Tests.ViewModels
             await _vm.LoadServersAsync();
             _vm.PingServers(_vm.ServerModels);
 
-            await Task.Delay(70); // Pinging is done in parallel operation and is not awaited
+            await Task.Delay(1200); // Ping uses up to ~800ms per relay; async void is not awaited
 
             // Assert
             Assert.NotEmpty(_vm.ServerModels);
-            Assert.True(_vm.ServerModels[0].Ping?.Contains("ms"));
-            Assert.Equal("✅", _vm.ServerModels[0].Status);
+            AssertPingSettled(_vm.ServerModels[0]);
         }
 
         [Fact]
@@ -167,13 +171,11 @@ namespace ServerPickerX.Tests.ViewModels
             _vm.SelectedDataGridServerModel = _vm.ServerModels[0];
             _vm.PingSelectedServer();
 
-            await Task.Delay(70); // Pinging is done in parallel operation and is not awaited
+            await Task.Delay(1200); // Ping uses up to ~800ms per relay; async void is not awaited
 
             // Assert
             Assert.NotEmpty(_vm.ServerModels);
-            var model = _vm.SelectedDataGridServerModel;
-            Assert.True(_vm.SelectedDataGridServerModel.Ping?.Contains("ms"));
-            Assert.Equal("✅", _vm.ServerModels[0].Status);
+            AssertPingSettled(_vm.SelectedDataGridServerModel!);
         }
 
         [Fact]
@@ -252,7 +254,7 @@ namespace ServerPickerX.Tests.ViewModels
 
             ObservableCollection<ServerModel> selectedServers = [_vm.ServerModels[0], _vm.ServerModels[2]];
 
-            _systemFirewallService.Setup(i => i.BlockServersAsync(selectedServers))
+            _systemFirewallService.Setup(i => i.BlockServersAsync(It.IsAny<ObservableCollection<ServerModel>>()))
                 .Callback((ObservableCollection<ServerModel> serverModels) => {
                     // Clear model relays to simulate a failed ICMP ping
                     foreach (var server in serverModels)
@@ -264,9 +266,11 @@ namespace ServerPickerX.Tests.ViewModels
 
             var result = await _vm.BlockSelectedAsync(selectedServers);
 
+            await Task.Delay(1200); // Non-selected rows still run async PingServer after PerformOperationAsync
+
             // Assert
             Assert.NotEmpty(_vm.ServerModels);
-            _systemFirewallService.Verify(i => i.BlockServersAsync(selectedServers)); // Verify method is invoked
+            _systemFirewallService.Verify(i => i.BlockServersAsync(It.IsAny<ObservableCollection<ServerModel>>()), Times.Once);
             Assert.True(result);
             foreach (var item in _vm.ServerModels.Select((value, index) => new { value, index }))
             {
@@ -276,8 +280,7 @@ namespace ServerPickerX.Tests.ViewModels
                     Assert.Equal("❌", item.value.Status);
                 } else
                 {
-                    Assert.True(item.value.Ping.Contains("ms"));
-                    Assert.Equal("✅", item.value.Status);
+                    AssertPingSettled(item.value);
                 }
             }
         }
@@ -297,7 +300,8 @@ namespace ServerPickerX.Tests.ViewModels
             _messageBoxService.Verify(i =>
                 i.ShowMessageBoxAsync(
                     _localizationService.Object.GetLocaleValue("MessageBoxInfoTitle"),
-                    _localizationService.Object.GetLocaleValue("SelectOneServerToBlockDialogue")
+                    _localizationService.Object.GetLocaleValue("SelectOneServerToBlockDialogue"),
+                    Icon.Info
                 ),
                 Times.Once()
             );
@@ -323,14 +327,13 @@ namespace ServerPickerX.Tests.ViewModels
 
             var result = await _vm.UnblockAllAsync();
 
-            await Task.Delay(70); // ping operations are fire-and-forget (background tasks)
+            await Task.Delay(1200); // ping operations are fire-and-forget (background tasks)
 
             // Assert
             Assert.True(result);
             foreach (var srv in _vm.ServerModels)
             {
-                Assert.Contains("ms", srv.Ping);
-                Assert.Equal("✅", srv.Status);
+                AssertPingSettled(srv);
             }
         }
 
@@ -384,7 +387,8 @@ namespace ServerPickerX.Tests.ViewModels
             _messageBoxService.Verify(i => 
                 i.ShowMessageBoxAsync(
                     _localizationService.Object.GetLocaleValue("MessageBoxInfoTitle"),
-                    _localizationService.Object.GetLocaleValue("SelectOneServerToUnblockDialogue")
+                    _localizationService.Object.GetLocaleValue("SelectOneServerToUnblockDialogue"),
+                    Icon.Info
                 ), 
                 Times.Once()
             );
@@ -452,14 +456,13 @@ namespace ServerPickerX.Tests.ViewModels
             // Act
             var result = await _vm.PerformOperationAsync(false, serverModels);
 
-            await Task.Delay(70); // ping operations are fire-and-forget (background tasks)
+            await Task.Delay(1200); // ping operations are fire-and-forget (background tasks)
 
             // Assert
             Assert.True(result);
             foreach (var srv in serverModels)
             {
-                Assert.Contains("ms", srv.Ping);
-                Assert.Equal("✅", srv.Status);
+                AssertPingSettled(srv);
             }
         }
 
@@ -489,6 +492,19 @@ namespace ServerPickerX.Tests.ViewModels
 
             Assert.Single(filtered);
             Assert.Contains(s1, filtered);
+        }
+
+        private static void AssertPingSettled(ServerModel model)
+        {
+            Assert.NotEqual("Pinging server", model.Ping);
+            if (model.Status == "✅")
+            {
+                Assert.Contains("ms", model.Ping ?? "");
+            }
+            else
+            {
+                Assert.Equal("❌", model.Status);
+            }
         }
 
         public object ReflectGetField(object obj, string propertyName)

--- a/ServerPickerX/Constants/BlockedServerDisplayGlyphs.cs
+++ b/ServerPickerX/Constants/BlockedServerDisplayGlyphs.cs
@@ -1,0 +1,8 @@
+namespace ServerPickerX.Constants
+{
+    public static class BlockedServerDisplayGlyphs
+    {
+        public const string Blocked = "❌";
+        public const string NotBlocked = "✅";
+    }
+}

--- a/ServerPickerX/Models/ServerModel.cs
+++ b/ServerPickerX/Models/ServerModel.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -22,6 +22,9 @@ namespace ServerPickerX.Models
 
         [ObservableProperty]
         public string? status;
+
+        [ObservableProperty]
+        public string? blockedStatus;
 
         public List<RelayModel> RelayModels { get; set; } = [];
 

--- a/ServerPickerX/ServerPickerX.csproj
+++ b/ServerPickerX/ServerPickerX.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <!-- Ensures all required .NET files are bundled -->
         <SelfContained>true</SelfContained> 
@@ -12,7 +12,7 @@
         <!-- Still have to enable this despite using source generators or JsonSerializerContext when serializing a class as json -->
         <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>

--- a/ServerPickerX/Services/Processes/RedirectedProcess.cs
+++ b/ServerPickerX/Services/Processes/RedirectedProcess.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace ServerPickerX.Services.Processes
+{
+    /// <summary>
+    /// Avoids deadlock when stdout/stderr are redirected: the child blocks if the pipe fills
+    /// while the parent waits for exit before reading. Reads must start before awaiting exit.
+    /// </summary>
+    internal static class RedirectedProcess
+    {
+        public static async Task<(string StandardOutput, string StandardError)> RunAsync(Process process)
+        {
+            process.Start();
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            return (await stdoutTask, await stderrTask);
+        }
+    }
+}

--- a/ServerPickerX/Services/SystemFirewalls/FirewallStateParsers.cs
+++ b/ServerPickerX/Services/SystemFirewalls/FirewallStateParsers.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace ServerPickerX.Services.SystemFirewalls
+{
+    internal static class FirewallParserSeparators
+    {
+        internal static readonly char[] NewLineSeparators = { '\r', '\n' };
+    }
+
+    public static class NetshAdvFirewallRuleNameParser
+    {
+        private const string RuleNamePrefix = "Rule Name:";
+
+        public static HashSet<string> ParseRuleNames(string stdout)
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(stdout))
+            {
+                return names;
+            }
+
+            foreach (var rawLine in stdout.Split(FirewallParserSeparators.NewLineSeparators, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var line = rawLine.Trim();
+                var idx = line.IndexOf(RuleNamePrefix, StringComparison.OrdinalIgnoreCase);
+                if (idx < 0)
+                {
+                    continue;
+                }
+
+                var name = line.AsSpan(idx + RuleNamePrefix.Length).Trim();
+                if (name.Length > 0)
+                {
+                    names.Add(name.ToString());
+                }
+            }
+
+            return names;
+        }
+    }
+
+    public static class IptablesInputDropParser
+    {
+        private static readonly Regex SourceRegex = new(@"-s\s+(\S+)", RegexOptions.Compiled);
+
+        public static List<HashSet<string>> ParseDropSourceIpSets(string stdout)
+        {
+            var result = new List<HashSet<string>>();
+            if (string.IsNullOrEmpty(stdout))
+            {
+                return result;
+            }
+
+            foreach (var rawLine in stdout.Split(FirewallParserSeparators.NewLineSeparators, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var line = rawLine.Trim();
+                if (!line.Contains("-j DROP", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var m = SourceRegex.Match(line);
+                if (!m.Success)
+                {
+                    continue;
+                }
+
+                var spec = m.Groups[1].Value;
+                var parts = spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (parts.Length == 0)
+                {
+                    continue;
+                }
+
+                var set = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var p in parts)
+                {
+                    if (p.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var slash = p.IndexOf('/');
+                    set.Add(slash >= 0 ? p[..slash] : p);
+                }
+
+                if (set.Count > 0)
+                {
+                    result.Add(set);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/ServerPickerX/Services/SystemFirewalls/ISystemFirewallService.cs
+++ b/ServerPickerX/Services/SystemFirewalls/ISystemFirewallService.cs
@@ -1,4 +1,5 @@
 using ServerPickerX.Models;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
@@ -9,5 +10,6 @@ namespace ServerPickerX.Services.SystemFirewalls
         Task BlockServersAsync(ObservableCollection<ServerModel> serverModels);
         Task UnblockServersAsync(ObservableCollection<ServerModel> serverModels);
         Task ResetFirewallAsync();
+        Task SyncBlockedStateAsync(IReadOnlyList<ServerModel> servers);
     }
 }

--- a/ServerPickerX/Services/SystemFirewalls/LinuxFirewallService.cs
+++ b/ServerPickerX/Services/SystemFirewalls/LinuxFirewallService.cs
@@ -1,9 +1,11 @@
+using ServerPickerX.Constants;
 using ServerPickerX.Models;
 using ServerPickerX.Services.Localizations;
 using ServerPickerX.Services.Loggers;
 using ServerPickerX.Services.MessageBoxes;
 using ServerPickerX.Services.Processes;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
@@ -31,11 +33,9 @@ namespace ServerPickerX.Services.SystemFirewalls
                     process.StartInfo.Arguments = "iptables " +
                         "-A INPUT -s " + ipAddresses + " -j DROP";
 
-                    process.Start();
-                    await process.WaitForExitAsync();
-
-                    string stdOut = process.StandardOutput.ReadToEnd().Trim();
-                    string stdErr = process.StandardError.ReadToEnd().Trim();
+                    var (stdOut, stdErr) = await RedirectedProcess.RunAsync(process);
+                    stdOut = stdOut.Trim();
+                    stdErr = stdErr.Trim();
 
                     if (process.ExitCode > 0)
                     {
@@ -63,11 +63,9 @@ namespace ServerPickerX.Services.SystemFirewalls
                     process.StartInfo.Arguments = "iptables " +
                        "-D INPUT -s " + ipAddresses + " -j DROP";
 
-                    process.Start();
-                    await process.WaitForExitAsync();
-
-                    string stdOut = process.StandardOutput.ReadToEnd().Trim();
-                    string stdErr = process.StandardError.ReadToEnd().Trim();
+                    var (stdOut, stdErr) = await RedirectedProcess.RunAsync(process);
+                    stdOut = stdOut.Trim();
+                    stdErr = stdErr.Trim();
 
                     if (process.ExitCode > 0)
                     {
@@ -101,11 +99,9 @@ namespace ServerPickerX.Services.SystemFirewalls
             {
                 process.StartInfo.Arguments = $"iptables -F";
 
-                process.Start();
-                process.WaitForExit();
-
-                string stdOut = process.StandardOutput.ReadToEnd().Trim();
-                string stdErr = process.StandardError.ReadToEnd().Trim();
+                var (stdOut, stdErr) = await RedirectedProcess.RunAsync(process);
+                stdOut = stdOut.Trim();
+                stdErr = stdErr.Trim();
 
                 if (process.ExitCode > 0)
                 {
@@ -122,6 +118,65 @@ namespace ServerPickerX.Services.SystemFirewalls
             {
                 // Perform debugging here if necessary (log error or through debugger breakpoints)
                 throw;
+            }
+        }
+
+        public async Task SyncBlockedStateAsync(IReadOnlyList<ServerModel> servers)
+        {
+            if (servers.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                using var process = _processService.CreateProcess("sudo");
+                process.StartInfo.Arguments = "iptables -S INPUT";
+
+                var (stdOut, stdErr) = await RedirectedProcess.RunAsync(process);
+                stdErr = stdErr.Trim();
+
+                if (process.ExitCode > 0)
+                {
+                    await _loggerService.LogWarningAsync(
+                        "SyncBlockedState iptables exit " + process.ExitCode + " StdErr: " + stdErr);
+                    ClearBlockedStatus(servers);
+                    return;
+                }
+
+                var dropSets = IptablesInputDropParser.ParseDropSourceIpSets(stdOut);
+
+                foreach (var server in servers)
+                {
+                    var relaySet = new HashSet<string>(StringComparer.Ordinal);
+                    foreach (var relay in server.RelayModels)
+                    {
+                        if (!string.IsNullOrWhiteSpace(relay.IPv4))
+                        {
+                            relaySet.Add(relay.IPv4.Trim());
+                        }
+                    }
+
+                    bool blocked = relaySet.Count > 0
+                        && dropSets.Exists(ds => ds.SetEquals(relaySet));
+
+                    server.BlockedStatus = blocked
+                        ? BlockedServerDisplayGlyphs.Blocked
+                        : BlockedServerDisplayGlyphs.NotBlocked;
+                }
+            }
+            catch (Exception ex)
+            {
+                await _loggerService.LogErrorAsync("SyncBlockedStateAsync (Linux) failed.", ex.Message);
+                ClearBlockedStatus(servers);
+            }
+        }
+
+        private static void ClearBlockedStatus(IReadOnlyList<ServerModel> servers)
+        {
+            foreach (var server in servers)
+            {
+                server.BlockedStatus = "";
             }
         }
     }

--- a/ServerPickerX/Services/SystemFirewalls/WindowsFirewallRuleName.cs
+++ b/ServerPickerX/Services/SystemFirewalls/WindowsFirewallRuleName.cs
@@ -1,0 +1,15 @@
+using ServerPickerX.Models;
+
+namespace ServerPickerX.Services.SystemFirewalls
+{
+    public static class WindowsFirewallRuleName
+    {
+        public const string NamePrefix = "server_picker_x_";
+
+        public static string ForDescription(string description) =>
+            NamePrefix + description.Replace(" ", "");
+
+        public static string ForServer(ServerModel server) =>
+            ForDescription(server.Description);
+    }
+}

--- a/ServerPickerX/Services/SystemFirewalls/WindowsFirewallService.cs
+++ b/ServerPickerX/Services/SystemFirewalls/WindowsFirewallService.cs
@@ -1,10 +1,11 @@
-using Avalonia.Logging;
+using ServerPickerX.Constants;
 using ServerPickerX.Models;
 using ServerPickerX.Services.Localizations;
 using ServerPickerX.Services.Loggers;
 using ServerPickerX.Services.MessageBoxes;
 using ServerPickerX.Services.Processes;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
@@ -31,16 +32,14 @@ namespace ServerPickerX.Services.SystemFirewalls
                 process.StartInfo.Arguments = $"/c {Path.Combine(Environment.SystemDirectory, "netsh.exe")} " +
                         "advfirewall firewall " +
                         "add rule " +
-                        "name=server_picker_x_" + serverModel.Description.Replace(" ", "") +
+                        "name=" + WindowsFirewallRuleName.ForServer(serverModel) +
                         " dir=out action=block protocol=ANY " + "remoteip=" + ipAddresses;
 
                 try
                 {
-                    process.Start();
-                    await process.WaitForExitAsync();
-
-                    string stdOut = process.StandardOutput.ReadToEnd().Trim();
-                    string stdErr = process.StandardError.ReadToEnd().Trim();
+                    var (stdOut, stdErr) = await RedirectedProcess.RunAsync(process);
+                    stdOut = stdOut.Trim();
+                    stdErr = stdErr.Trim();
 
                     if (process.ExitCode > 0)
                     {
@@ -66,15 +65,13 @@ namespace ServerPickerX.Services.SystemFirewalls
                 process.StartInfo.Arguments = $"/c {Path.Combine(Environment.SystemDirectory, "netsh.exe")} " +
                         "advfirewall firewall " +
                         "delete rule " +
-                        "name=server_picker_x_" + serverModel.Description.Replace(" ", "");
+                        "name=" + WindowsFirewallRuleName.ForServer(serverModel);
 
                 try
                 {
-                    process.Start();
-                    await process.WaitForExitAsync();
-
-                    string stdOut = process.StandardOutput.ReadToEnd().Trim();
-                    string stdErr = process.StandardError.ReadToEnd().Trim();
+                    var (stdOut, stdErr) = await RedirectedProcess.RunAsync(process);
+                    stdOut = stdOut.Trim();
+                    stdErr = stdErr.Trim();
 
                     if (process.ExitCode > 0)
                     {
@@ -108,11 +105,9 @@ namespace ServerPickerX.Services.SystemFirewalls
             {
                 process.StartInfo.Arguments = $"/c {Path.Combine(Environment.SystemDirectory, "netsh.exe")} advfirewall reset";
 
-                process.Start();
-                process.WaitForExit();
-
-                string stdOut = process.StandardOutput.ReadToEnd().Trim();
-                string stdErr = process.StandardError.ReadToEnd().Trim();
+                var (stdOut, stdErr) = await RedirectedProcess.RunAsync(process);
+                stdOut = stdOut.Trim();
+                stdErr = stdErr.Trim();
 
                 if (process.ExitCode > 0)
                 {
@@ -129,6 +124,55 @@ namespace ServerPickerX.Services.SystemFirewalls
             {
                 // Perform debugging here if necessary (log error or through debugger breakpoints)
                 throw;
+            }
+        }
+
+        public async Task SyncBlockedStateAsync(IReadOnlyList<ServerModel> servers)
+        {
+            if (servers.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                using var process = _processService.CreateProcess("cmd.exe");
+                process.StartInfo.Arguments = $"/c {Path.Combine(Environment.SystemDirectory, "netsh.exe")} " +
+                    "advfirewall firewall show rule name=all";
+
+                var (stdOut, stdErr) = await RedirectedProcess.RunAsync(process);
+                stdErr = stdErr.Trim();
+
+                if (process.ExitCode > 0)
+                {
+                    await _loggerService.LogWarningAsync(
+                        "SyncBlockedState netsh exit " + process.ExitCode + " StdErr: " + stdErr);
+                    ClearBlockedStatus(servers);
+                    return;
+                }
+
+                var ruleNames = NetshAdvFirewallRuleNameParser.ParseRuleNames(stdOut);
+
+                foreach (var server in servers)
+                {
+                    bool blocked = ruleNames.Contains(WindowsFirewallRuleName.ForServer(server));
+                    server.BlockedStatus = blocked
+                        ? BlockedServerDisplayGlyphs.Blocked
+                        : BlockedServerDisplayGlyphs.NotBlocked;
+                }
+            }
+            catch (Exception ex)
+            {
+                await _loggerService.LogErrorAsync("SyncBlockedStateAsync (Windows) failed.", ex.Message);
+                ClearBlockedStatus(servers);
+            }
+        }
+
+        private static void ClearBlockedStatus(IReadOnlyList<ServerModel> servers)
+        {
+            foreach (var server in servers)
+            {
+                server.BlockedStatus = "";
             }
         }
     }

--- a/ServerPickerX/ViewModels/MainWindowViewModel.cs
+++ b/ServerPickerX/ViewModels/MainWindowViewModel.cs
@@ -129,6 +129,10 @@ namespace ServerPickerX.ViewModels
             ServerModels.AddRange(serverModels);
 
             PingServers(serverModels);
+
+            // Do not await: netsh "show rule name=all" can take a long time and would block LoadServersAsync
+            // before DataContext is assigned (empty grid + stuck-looking UI).
+            _ = SyncBlockedStateAsync();
         }
 
         [RelayCommand]
@@ -239,6 +243,7 @@ namespace ServerPickerX.ViewModels
             PendingOperation = true;
             ShowProgressBar = true;
 
+            var success = true;
             try
             {
                 if (shouldBlock)
@@ -259,25 +264,49 @@ namespace ServerPickerX.ViewModels
             }
             catch (Exception ex)
             {
+                success = false;
                 await _loggerService.LogErrorAsync("An error has occurred while blocking or unblocking servers.", ex.Message);
 
                 await _messageBoxService.ShowMessageBoxAsync(
                     "Error",
                     "Oops! Something went wrong. Please upload the log file to GitHub."
                     );
-
-                return false;
+            }
+            finally
+            {
+                PendingOperation = false;
+                ShowProgressBar = false;
             }
 
-            PendingOperation = false;
-            ShowProgressBar = false;
+            // Refresh blocked column without blocking the progress UI on slow netsh dump
+            if (ServerModels.Count > 0)
+            {
+                _ = SyncBlockedStateAsync();
+            }
 
-            return true;
+            return success;
         }
 
         public IServerDataService GetServerDataService()
         {
             return _serverDataService;
+        }
+
+        public async Task SyncBlockedStateAsync()
+        {
+            if (ServerModels.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                await _systemFirewallService.SyncBlockedStateAsync(ServerModels.ToList());
+            }
+            catch (Exception ex)
+            {
+                await _loggerService.LogErrorAsync("SyncBlockedStateAsync failed.", ex.Message);
+            }
         }
 
     }

--- a/ServerPickerX/Views/MainWindow.axaml
+++ b/ServerPickerX/Views/MainWindow.axaml
@@ -159,6 +159,7 @@
 							<DataGridTextColumn Width="*" Header="Server Name" Binding="{Binding Description}" />
 							<DataGridTextColumn Width="128" Header="Ping" Binding="{Binding Ping}" HeaderPointerPressed="DataGridTextColumn_HeaderPointerPressed" />
 							<DataGridTextColumn Width="100" Header="Status" Binding="{Binding Status}" />
+							<DataGridTextColumn Width="100" Header="Blocked" Binding="{Binding BlockedStatus}" />
                         </DataGrid.Columns>
 						<DataGrid.Styles>
                             <Style Selector="DataGridColumnHeader">

--- a/ServerPickerX/Views/MainWindow.axaml.cs
+++ b/ServerPickerX/Views/MainWindow.axaml.cs
@@ -144,6 +144,8 @@ namespace ServerPickerX.Views
             if (vm.ServersLoaded)
             {
                 await SyncServersAsync(vm);
+                // Fire-and-forget: firewall rule dump must not delay first paint / DataContext binding
+                _ = vm.SyncBlockedStateAsync();
             }
 
             await _versionService.CheckVersionAsync();

--- a/ServerPickerX/Views/UserControls/TitleBarButtons.axaml.cs
+++ b/ServerPickerX/Views/UserControls/TitleBarButtons.axaml.cs
@@ -13,15 +13,17 @@ public partial class TitleBarButtons : UserControl
 
     private void MinimizeBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        var parentWindow = TopLevel.GetTopLevel(this) as Window;
-
-        parentWindow?.WindowState = WindowState.Minimized;
+        if (TopLevel.GetTopLevel(this) is Window parentWindow)
+        {
+            parentWindow.WindowState = WindowState.Minimized;
+        }
     }
 
     private void CloseBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        var parentWindow = TopLevel.GetTopLevel(this) as Window;
-
-        parentWindow?.Close();
+        if (TopLevel.GetTopLevel(this) is Window parentWindow)
+        {
+            parentWindow.Close();
+        }
     }
 }


### PR DESCRIPTION
## Disclosure

**This pull request was authored with assistance from AI** (automated coding / an AI assistant). Please review the diff and run checks locally before merging.

## Testing note

**These changes have only been tested on Windows.** Linux paths (`iptables` sync, `RedirectedProcess` usage) were updated for consistency with the Windows fix but were **not** verified on a Linux machine.

## Summary

- **Blocked column:** Sync firewall state into the grid (`ServerModel.BlockedStatus`) via `ISystemFirewallService.SyncBlockedStateAsync` — Windows (`netsh advfirewall firewall show rule name=all` + rule name parsing) and Linux (`iptables -S INPUT` + drop-set matching).
- **UI responsiveness:** Run firewall sync in the background after load / operations so the server list and progress UI are not blocked by slow `netsh` / `iptables`.
- **`RedirectedProcess`:** Start `ReadToEndAsync()` on stdout/stderr *before* `WaitForExitAsync()` so large `netsh` output cannot fill the pipe and deadlock the child (fixes the Blocked column never updating on Windows).
- **Tests:** Parser unit tests; VM tests updated with Moq `ISystemFirewallService`.

## Verification

`dotnet test` — 27 passed at time of commit.