### PR TITLE
Reduce memory consumption by 10x

### DIFF
--- a/ServerPickerX/Program.cs
+++ b/ServerPickerX/Program.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Projektanker.Icons.Avalonia;
 using Projektanker.Icons.Avalonia.FontAwesome;
 using System;
@@ -22,6 +22,10 @@ namespace ServerPickerX
 
             return AppBuilder.Configure<App>()
                 .UsePlatformDetect()
+                .With(new Win32PlatformOptions
+                {
+                    RenderingMode = [Win32RenderingMode.Software],
+                })
                 .WithInterFont()
                 .LogToTrace();
         }

--- a/ServerPickerX/ServerPickerX.csproj
+++ b/ServerPickerX/ServerPickerX.csproj
@@ -22,8 +22,8 @@
         <PackageProjectUrl>https://github.com/FN-FAL113/server-picker-x</PackageProjectUrl>
         <RepositoryUrl>https://github.com/FN-FAL113/server-picker-x</RepositoryUrl>
         <ApplicationIcon>Assets\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.0.5.0</AssemblyVersion>
-        <FileVersion>1.0.5.0</FileVersion>
+        <AssemblyVersion>1.0.6.0</AssemblyVersion>
+        <FileVersion>1.0.6.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
By default, the Avalonia library uses GPU acceleration with OpenGL / Direct3D / Vulkan. This is quite overkill for an app as simple as this with not much graphics going on, and it turns this lightweight app into a 500MB RAM hog from all the GPU libraries being loaded. This PR switches Avalonia to software rendering, cutting RAM usage from 500-550MB to 50-60MB.