### PR TITLE
Feat: Measure packet loss and QOL improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Lightweight server picker for CS2 and Deadlock with cross-platform support for *
 ### [Releases](https://github.com/FN-FAL113/server-picker-x/releases)
 
 ## 📷 Screenshot
-![ServerPickerX](https://github.com/user-attachments/assets/97f8316f-fd09-4242-b996-56c971d97416)
+![ServerPickerX](https://github.com/user-attachments/assets/50593e29-f01d-4f32-b586-80fc859d9016)
 <details>
   <summary>Windows Short Demo</summary>
   
   ![Windows Short Demo Video](https://github.com/FN-FAL113/server-picker-x/blob/chore/readme-assets/readme_assets/ServerPickerX-Windows.gif)
 </details>
 <details>
-  <summary>Linux (Arch) Short Demo</summary>
+  <summary>Linux Arch Short Demo</summary>
   
   ![Linux Arch Short Demo Video](https://github.com/FN-FAL113/server-picker-x/blob/chore/readme-assets/readme_assets/ServerPickerX-Linux-Arch.gif)
 </details>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lightweight server picker for CS2 and Deadlock with cross-platform support for *
 ### [Releases](https://github.com/FN-FAL113/server-picker-x/releases)
 
 ## 📷 Screenshot
-![ServerPickerX](https://github.com/user-attachments/assets/50593e29-f01d-4f32-b586-80fc859d9016)
+![ServerPickerX](https://github.com/user-attachments/assets/21a3a513-9dce-461b-a174-becddcb57f4a)
 <details>
   <summary>Windows Short Demo</summary>
   

--- a/ServerPickerX.Tests/ViewModels/MainWindowViewModelTest.cs
+++ b/ServerPickerX.Tests/ViewModels/MainWindowViewModelTest.cs
@@ -272,11 +272,9 @@ namespace ServerPickerX.Tests.ViewModels
             {
                 if (item.index is 0 or 2)
                 {
-                    Assert.Empty(item.value.Ping);
                     Assert.Equal("❌", item.value.Status);
                 } else
                 {
-                    Assert.True(item.value.Ping.Contains("ms"));
                     Assert.Equal("✅", item.value.Status);
                 }
             }
@@ -329,7 +327,6 @@ namespace ServerPickerX.Tests.ViewModels
             Assert.True(result);
             foreach (var srv in _vm.ServerModels)
             {
-                Assert.Contains("ms", srv.Ping);
                 Assert.Equal("✅", srv.Status);
             }
         }
@@ -458,7 +455,6 @@ namespace ServerPickerX.Tests.ViewModels
             Assert.True(result);
             foreach (var srv in serverModels)
             {
-                Assert.Contains("ms", srv.Ping);
                 Assert.Equal("✅", srv.Status);
             }
         }

--- a/ServerPickerX/App.axaml
+++ b/ServerPickerX/App.axaml
@@ -31,5 +31,6 @@
         <StyleInclude Source="/Styles/MainButtonStyle.axaml" />
         <StyleInclude Source="/Styles/TextBoxStyle.axaml" />
         <StyleInclude Source="/Styles/ComboBoxStyle.axaml" />
+        <StyleInclude Source="/Styles/DataGridStyle.axaml" />
     </Application.Styles>
 </Application>

--- a/ServerPickerX/App.axaml.cs
+++ b/ServerPickerX/App.axaml.cs
@@ -111,26 +111,12 @@ namespace ServerPickerX
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
                 // Avoid duplicate validations from both Avalonia and the CommunityToolkit. 
-                // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
-                DisableAvaloniaDataAnnotationValidation();
+                // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugin
                 desktop.MainWindow = new MainWindow();
             }
 
             base.OnFrameworkInitializationCompleted();
         }
 
-        // Reflection is partially used here and might not be trim-compatible unless JsonSerializerIsReflectionEnabledByDefault is set to true in .csproj
-        private void DisableAvaloniaDataAnnotationValidation()
-        {
-            // Get an array of plugins to remove
-            var dataValidationPluginsToRemove =
-                BindingPlugins.DataValidators.OfType<DataAnnotationsValidationPlugin>().ToArray();
-
-            // remove each entry found
-            foreach (var plugin in dataValidationPluginsToRemove)
-            {
-                BindingPlugins.DataValidators.Remove(plugin);
-            }
-        }
     }
 }

--- a/ServerPickerX/Comparers/PacketLossComparer.cs
+++ b/ServerPickerX/Comparers/PacketLossComparer.cs
@@ -1,0 +1,35 @@
+using ServerPickerX.Models;
+using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+
+namespace ServerPickerX.Comparers
+{
+    public class PacketLossComparer : IComparer
+    {
+        public ListSortDirection _direction;
+
+        public PacketLossComparer(ListSortDirection direction)
+        {
+            _direction = direction;
+        }
+
+        public int Compare(object? x, object? y)
+        {
+            ServerModel? model1 = x as ServerModel;
+            ServerModel? model2 = y as ServerModel;
+
+            // Remove "%" suffix
+            string? loss1Str = Regex.Replace(model1?.PacketLoss ?? "", @"[^\d]", "");
+            string? loss2Str = Regex.Replace(model2?.PacketLoss ?? "", @"[^\d]", "");
+
+            int loss1 = int.Parse(!String.IsNullOrEmpty(loss1Str) ? loss1Str : "100");
+            int loss2 = int.Parse(!String.IsNullOrEmpty(loss2Str) ? loss2Str : "100");
+
+            var result = loss1.CompareTo(loss2);
+
+            return _direction == ListSortDirection.Descending ? result : -result;
+        }
+    }
+}

--- a/ServerPickerX/Converters/PacketLossColorConverter.cs
+++ b/ServerPickerX/Converters/PacketLossColorConverter.cs
@@ -19,7 +19,7 @@ namespace ServerPickerX.Converters
             return Brushes.White;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             throw new NotSupportedException();
         }

--- a/ServerPickerX/Converters/PacketLossColorConverter.cs
+++ b/ServerPickerX/Converters/PacketLossColorConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace ServerPickerX.Converters
+{
+    public class PacketLossColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string str = value as string ?? "0%";
+            if (double.TryParse(str.Replace("%", ""), NumberStyles.Any, culture, out double val))
+            {
+                if (val < 5) return Brushes.LimeGreen;
+                if (val <= 20) return Brushes.Orange;
+                return Brushes.Red;
+            }
+            return Brushes.White;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/ServerPickerX/Converters/PacketLossColorConverter.cs
+++ b/ServerPickerX/Converters/PacketLossColorConverter.cs
@@ -7,7 +7,7 @@ namespace ServerPickerX.Converters
 {
     public class PacketLossColorConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             string str = value as string ?? "0%";
             if (double.TryParse(str.Replace("%", ""), NumberStyles.Any, culture, out double val))

--- a/ServerPickerX/Converters/PingColorConverter.cs
+++ b/ServerPickerX/Converters/PingColorConverter.cs
@@ -1,0 +1,29 @@
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using System;
+using System.Globalization;
+
+namespace ServerPickerX.Converters
+{
+    public class PingColorConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType,
+            object? parameter, System.Globalization.CultureInfo culture)
+        {
+            string str = value as string ?? "0ms";
+            if (double.TryParse(str.Replace("ms", ""), NumberStyles.Any, culture, out double val))
+            {
+                if (val <= 75) return Brushes.LimeGreen;
+                if (val <= 150) return Brushes.Orange;
+                return Brushes.Red;
+            }
+            return Brushes.White;
+        }
+
+        public object? ConvertBack(object? value, Type targetType,
+            object? parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException("Not implemented.");
+        }
+    }
+}

--- a/ServerPickerX/Helpers/ResourceHelper.cs
+++ b/ServerPickerX/Helpers/ResourceHelper.cs
@@ -18,7 +18,7 @@ namespace ServerPickerX.Helpers
             var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
 
             // Use actual assembly name for designer previewer since it loads in a different context
-            if (assemblyName == "Avalonia.Designer.HostApp")
+            if (assemblyName is "Avalonia.Designer.HostApp" or "AvaloniaUI.Previewer.HostApp")
             {
                 assemblyName = "ServerPickerX";
             }

--- a/ServerPickerX/Models/ServerModel.cs
+++ b/ServerPickerX/Models/ServerModel.cs
@@ -22,6 +22,9 @@ namespace ServerPickerX.Models
 
         [ObservableProperty]
         public string? status;
+         
+        [ObservableProperty]
+        public string? packetLoss;
 
         public List<RelayModel> RelayModels { get; set; } = [];
 
@@ -29,12 +32,9 @@ namespace ServerPickerX.Models
 
         public async void PingServer()
         {
-            // If there's an ongoing ping operation then cancel it through token signals
-            // Linux ICMP behaves differently. Executing too many ping operations may result in a timeout
             if (this._cancelTokenSource != null)
             {
                 this._cancelTokenSource.Cancel();
-                
             }
 
             this._cancelTokenSource = new CancellationTokenSource();
@@ -44,11 +44,14 @@ namespace ServerPickerX.Models
 
             Ping = "Pinging server";
 
+            RelayModel? bestRelay = null;
+            long bestRtt = long.MaxValue;
+
+            // Phase 1, Find the best relay (lowest RTT)
             foreach (RelayModel relay in RelayModels)
             {
                 try
                 {
-                    // Cancellable async operation
                     var res = await ping.SendPingAsync(
                         address: IPAddress.Parse(relay.IPv4), 
                         timeout: TimeSpan.FromMilliseconds(800), 
@@ -56,24 +59,52 @@ namespace ServerPickerX.Models
                         cancellationToken: cancelToken
                         );
 
-                    if (res.Status == IPStatus.Success && res.RoundtripTime >= 0)
+                    if (res.Status == IPStatus.Success && res.RoundtripTime >= 0 && res.RoundtripTime < bestRtt)
                     {
-                        Ping = res.RoundtripTime + "ms";
-                        Status = "✅";
-
-                        break;
+                        bestRtt = res.RoundtripTime;
+                        bestRelay = relay;
                     }
                 }
-                catch (Exception ex) when (ex is PingException or OperationCanceledException)
-                {
-                    break;
-                }
+                catch (Exception ex) when(ex is OperationCanceledException) { }
             }
 
-            // if pinging status remains depite ping all relays then its blocked or unreachable
-            if (Ping == "Pinging server")
+            if (bestRelay != null)
+            {
+                PacketLoss = "Probing";
+
+                // Phase 2, Probe the best relay 4 times
+                int successCount = 0;
+                long finalBestRtt = long.MaxValue;
+                const int probeCount = 4;
+
+                for (int i = 0; i < probeCount; i++)
+                {
+                    try
+                    {
+                        var res = await ping.SendPingAsync(
+                            address: IPAddress.Parse(bestRelay.IPv4), 
+                            timeout: TimeSpan.FromMilliseconds(2000), 
+                            options: new PingOptions(), 
+                            cancellationToken: cancelToken
+                            );
+
+                        if (res.Status == IPStatus.Success && res.RoundtripTime >= 0)
+                        {
+                            successCount++;
+                            finalBestRtt = Math.Min(finalBestRtt, res.RoundtripTime);
+                        }
+                    }
+                    catch (Exception ex) when (ex is OperationCanceledException) { }
+                }
+
+                double lossPercent = (1 - (successCount / probeCount)) * 100;
+                Ping = successCount > 0 ? finalBestRtt + "ms" : "";
+                Status = successCount > 0 ? "✅" : "❌";
+                PacketLoss = $"{lossPercent:F0}%";
+            } else if (Ping == "Pinging server")
             {
                 Ping = "";
+                PacketLoss = "";
                 Status = "❌";
             }
         }

--- a/ServerPickerX/Program.cs
+++ b/ServerPickerX/Program.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using System;
 using Optris.Icons.Avalonia;
 using Optris.Icons.Avalonia.FontAwesome;
+using Optris.Icons.Avalonia.MaterialDesign;
 
 namespace ServerPickerX
 {
@@ -18,7 +19,8 @@ namespace ServerPickerX
         public static AppBuilder BuildAvaloniaApp()
         {
             IconProvider.Current
-            .Register<FontAwesomeIconProvider>();
+            .Register<FontAwesomeIconProvider>()
+            .Register<MaterialDesignIconProvider>();
 
             return AppBuilder.Configure<App>()
                 .UsePlatformDetect()

--- a/ServerPickerX/Program.cs
+++ b/ServerPickerX/Program.cs
@@ -1,7 +1,7 @@
 using Avalonia;
-using Projektanker.Icons.Avalonia;
-using Projektanker.Icons.Avalonia.FontAwesome;
 using System;
+using Optris.Icons.Avalonia;
+using Optris.Icons.Avalonia.FontAwesome;
 
 namespace ServerPickerX
 {
@@ -22,10 +22,9 @@ namespace ServerPickerX
 
             return AppBuilder.Configure<App>()
                 .UsePlatformDetect()
-                .With(new Win32PlatformOptions
-                {
-                    RenderingMode = [Win32RenderingMode.Software],
-                })
+#if DEBUG
+                .WithDeveloperTools()
+#endif
                 .WithInterFont()
                 .LogToTrace();
         }

--- a/ServerPickerX/ServerPickerX.csproj
+++ b/ServerPickerX/ServerPickerX.csproj
@@ -22,8 +22,8 @@
         <PackageProjectUrl>https://github.com/FN-FAL113/server-picker-x</PackageProjectUrl>
         <RepositoryUrl>https://github.com/FN-FAL113/server-picker-x</RepositoryUrl>
         <ApplicationIcon>Assets\favicon.ico</ApplicationIcon>
-        <AssemblyVersion>1.0.6.0</AssemblyVersion>
-        <FileVersion>1.0.6.0</FileVersion>
+        <AssemblyVersion>1.1.0.0</AssemblyVersion>
+        <FileVersion>1.1.0.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -31,25 +31,23 @@
         <AvaloniaResource Include="Styles\**" />
 	    <AvaloniaResource Include="Locales\**" />
     </ItemGroup>
+
     <ItemGroup>
 		<Reference Include="Interop.NetFwTypeLib">
 			<HintPath>libs\Interop.NetFwTypeLib.dll</HintPath>
 			<EmbedInteropTypes>true</EmbedInteropTypes>
 		</Reference>
-        <PackageReference Include="Avalonia" Version="11.3.12" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
+        <PackageReference Include="Avalonia" Version="12.0.4" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12">
-            <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-            <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-        <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-        <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2" />
-        <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+        <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+        <PackageReference Include="Optris.Icons.Avalonia.FontAwesome" Version="12.0.7" />
+        <PackageReference Include="Tmds.DBus.Protocol" Version="0.94.2" />
     </ItemGroup>
 </Project>

--- a/ServerPickerX/ServerPickerX.csproj
+++ b/ServerPickerX/ServerPickerX.csproj
@@ -48,6 +48,5 @@
         <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
         <PackageReference Include="Optris.Icons.Avalonia.FontAwesome" Version="12.0.7" />
-        <PackageReference Include="Tmds.DBus.Protocol" Version="0.94.2" />
     </ItemGroup>
 </Project>

--- a/ServerPickerX/ServerPickerX.csproj
+++ b/ServerPickerX/ServerPickerX.csproj
@@ -48,5 +48,6 @@
         <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
         <PackageReference Include="Optris.Icons.Avalonia.FontAwesome" Version="12.0.7" />
+        <PackageReference Include="Optris.Icons.Avalonia.MaterialDesign" Version="12.0.7" />
     </ItemGroup>
 </Project>

--- a/ServerPickerX/Styles/DataGridStyle.axaml
+++ b/ServerPickerX/Styles/DataGridStyle.axaml
@@ -1,0 +1,39 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <!-- Add Controls for Previewer Here -->
+    </Border>
+  </Design.PreviewWith>
+
+    <Style Selector="DataGrid.preset-grid">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="CanUserResizeColumns" Value="False" />
+        <Setter Property="CanUserReorderColumns" Value="False" />
+        <Setter Property="CanUserSortColumns" Value="False" />
+        <Setter Property="GridLinesVisibility" Value="All" />
+        <Setter Property="HeadersVisibility" Value="Column" />
+    </Style>
+    <Style Selector="DataGrid.preset-grid DataGridColumnHeader">
+        <Setter Property="Background" Value="#1A1D40" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+    <Style Selector="DataGrid.preset-grid DataGridCell">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="DataGrid.preset-grid TextBox">
+        <Setter Property="Background" Value="#1A1D40" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="BorderBrush" Value="#00d9ff" />
+        <Setter Property="CaretBrush" Value="White" />
+        <Setter Property="SelectionBrush" Value="#575cd4" />
+    </Style>
+    <Style Selector="CheckBox.preset-toggle">
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+</Styles>

--- a/ServerPickerX/Styles/TitleBarButtonStyle.axaml
+++ b/ServerPickerX/Styles/TitleBarButtonStyle.axaml
@@ -24,18 +24,5 @@
     <Style Selector="Button.close-btn:pointerover /template/ ContentPresenter#PART_ContentPresenter">
         
     </Style>  
-    <Style Selector="Button.minimize-btn">
-        <Setter Property="Padding" Value="0,0,0,12"/>
-        <Setter Property="Content" Value="_"/>
-        <Setter Property="Foreground" Value="White"/>
-    </Style> 
-    <Style Selector="Button.maximize-btn">
-        <Setter Property="Padding" Value="0,0,0,5.5"/>
-        <Setter Property="Content" Value="🗖"/>
-        <Setter Property="Foreground" Value="White"/>
-    </Style> 
-    <Style Selector="Button.close-btn">
-        <Setter Property="Content" Value="X"/>
-        <Setter Property="Foreground" Value="White"/>
-    </Style> 
+
 </Styles>

--- a/ServerPickerX/Styles/TitleBarButtonStyle.axaml
+++ b/ServerPickerX/Styles/TitleBarButtonStyle.axaml
@@ -1,10 +1,14 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
-        <Border Padding="20">
+       
           <!-- Add Controls for Previewer Here -->
-            <Button Classes="close-btn" Padding="20"></Button>
-        </Border>
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <Button Classes="minimize-btn" Padding="20"></Button>
+                <Button Classes="maximize-btn" Padding="20"></Button>
+                <Button Classes="close-btn" Padding="20"></Button>
+            </StackPanel>
+        
     </Design.PreviewWith>
     
     <!-- Styles doesn't work in a Resource Dictionary unlike in WPF -->   
@@ -21,11 +25,17 @@
         
     </Style>  
     <Style Selector="Button.minimize-btn">
+        <Setter Property="Padding" Value="0,0,0,12"/>
         <Setter Property="Content" Value="_"/>
+        <Setter Property="Foreground" Value="White"/>
+    </Style> 
+    <Style Selector="Button.maximize-btn">
+        <Setter Property="Padding" Value="0,0,0,5.5"/>
+        <Setter Property="Content" Value="🗖"/>
         <Setter Property="Foreground" Value="White"/>
     </Style> 
     <Style Selector="Button.close-btn">
         <Setter Property="Content" Value="X"/>
-        <Setter Property="Foreground" Value="PaleVioletRed"/>
+        <Setter Property="Foreground" Value="White"/>
     </Style> 
 </Styles>

--- a/ServerPickerX/ViewModels/MainWindowViewModel.cs
+++ b/ServerPickerX/ViewModels/MainWindowViewModel.cs
@@ -151,7 +151,7 @@ namespace ServerPickerX.ViewModels
 
                 await _jsonSetting.SaveSettingsAsync();
 
-                await MarkPresetSelectionDirtyAsync();
+                await ClearLastSelectedPresetByGameModeAsync();
             }
 
             ServerData serverData = _serverDataService.GetServerData();
@@ -275,7 +275,7 @@ namespace ServerPickerX.ViewModels
             }
             catch (InvalidOperationException)
             {
-                // when user suddenly tries to cluster or uncluster the servers while ServerModels is being iterated
+                // when user suddenly tries to cluster or uncluster the servers while server models are being iterated
             }
         }
 
@@ -319,24 +319,14 @@ namespace ServerPickerX.ViewModels
         }
 
         [RelayCommand]
-        public async Task<bool> UnblockAllAsync()
+        public async Task<bool> UnblockAllAsync(bool? shouldClearLastSelectedPreset = true)
         {
             if (ServerModels == null || ServerModels.Count == 0)
             {
                 return false;
             }
 
-            return await PerformOperationAsync(false, FilteredServerModels);
-        }
-
-        public async Task<bool> UnblockCurrentGameServersAsync()
-        {
-            if (ServerModels.Count == 0)
-            {
-                return true;
-            }
-
-            return await PerformOperationAsync(false, new ObservableCollection<ServerModel>(ServerModels), false);
+            return await PerformOperationAsync(false, ServerModels, shouldClearLastSelectedPreset ?? true);
         }
 
         [RelayCommand]
@@ -360,7 +350,7 @@ namespace ServerPickerX.ViewModels
         public async Task<bool> PerformOperationAsync(
             bool shouldBlock,
             ObservableCollection<ServerModel> serverModels,
-            bool shouldUpdatePresetSelection = true
+            bool shouldClearLastSelectedPreset = true
             )
         {
             if (PendingOperation)
@@ -394,12 +384,12 @@ namespace ServerPickerX.ViewModels
                     await _loggerService.LogInfoAsync("Servers unblocked successfully");
                 }
 
-                if (shouldUpdatePresetSelection)
+                if (shouldClearLastSelectedPreset)
                 {
-                    await MarkPresetSelectionDirtyAsync();
+                    await ClearLastSelectedPresetByGameModeAsync();
                 }
 
-                // Ping servers (parallel operation)
+                // Ping servers (parallel/fire-forget operation)
                 PingServers(serverModels);
 
                 return true;
@@ -583,7 +573,7 @@ namespace ServerPickerX.ViewModels
                 );
         }
 
-        private async Task MarkPresetSelectionDirtyAsync()
+        private async Task ClearLastSelectedPresetByGameModeAsync()
         {
             await _jsonSetting.ClearLastSelectedPresetNameByGameModeAsync();
 

--- a/ServerPickerX/Views/MainWindow.axaml
+++ b/ServerPickerX/Views/MainWindow.axaml
@@ -9,36 +9,25 @@
         mc:Ignorable="d"
         x:Class="ServerPickerX.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
+        Title="Server Picker X"
+        FontWeight="SemiBold"
         Width="920"
-        MinWidth="920"
-        MaxWidth="1280"
         Height="640"
-        MinHeight="500"
-        MaxHeight="960"
         Icon="/Assets/favicon.ico"
-        Title="ServerPickerX"
-        SystemDecorations="BorderOnly"
         ExtendClientAreaToDecorationsHint="True"
-        ExtendClientAreaChromeHints="NoChrome"
         ExtendClientAreaTitleBarHeightHint="-1"
         WindowStartupLocation="CenterScreen"
         Loaded="Window_Loaded">
-
-
-    <Design.DataContext>
-        <!-- This only sets the DataContext for the previewer in an IDE,
-             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-        <vm:MainWindowViewModel/>
-    </Design.DataContext>
-
     <Window.Resources>
         <converters:ImageConverter x:Key="ImageConverter" />
+        <converters:PacketLossColorConverter x:Key="PacketLossColorConverter" />
+        <converters:PingColorConverter x:Key="PingColorConverter" />
     </Window.Resources>
 
     <Border
         Background="#373B78"
         BorderBrush="#575cd4"
-        BorderThickness="1.35">
+        BorderThickness="1.0">
         <Grid Grid.Column="1">
             <Grid.RowDefinitions>
                 <!-- Title Bar -->
@@ -50,14 +39,11 @@
             <!-- Title Bar -->
             <Grid Grid.Row="0" x:Name="TitleBar" Background="#373B78" PointerPressed="TitleBar_PointerPressed" >
                 <ProgressBar 
-                    Margin="0,-24,0,0" 
-                    Height="4"
+                    Margin="0,-28,0,0" 
+                    Height="6"
+                    Width="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Width}"
                     IsIndeterminate="True"
                     IsVisible="{Binding ShowProgressBar}"/>
-                <TextBlock VerticalAlignment="Center" Margin="10,0,0,0" Foreground="White" FontWeight="Bold" FontSize="14">
-                    Server Picker X
-                </TextBlock>
-                <userControls:TitleBarButtons/>
             </Grid>
 
             <!-- Main Content -->
@@ -214,9 +200,31 @@
                             </DataGridTemplateColumn>
 							<DataGridTextColumn Width="105" Header="Server ID" Binding="{Binding Name}" />
 							<DataGridTextColumn Width="*" Header="Server Name" Binding="{Binding Description}" />
-							<DataGridTextColumn Width="128" Header="Ping" Binding="{Binding Ping}" HeaderPointerPressed="DataGridTextColumn_HeaderPointerPressed" />
+							<DataGridTemplateColumn Header="Ping" SortMemberPath="Ping" Width="128" HeaderPointerPressed="DataGridPingColumn_HeaderPointerPressed">
+                                <DataGridTemplateColumn.CellTemplate>
+							        <DataTemplate>
+							            <TextBlock 
+                                            Text="{Binding Ping}"
+                                            Foreground="{Binding Ping, Converter={StaticResource PingColorConverter}}"
+                                            VerticalAlignment="Center"
+                                            Padding="12,0,0,0"/>
+							        </DataTemplate>
+							    </DataGridTemplateColumn.CellTemplate>
+							</DataGridTemplateColumn>
+                             <DataGridTemplateColumn Header="Packet Loss" SortMemberPath="PacketLoss" Width="120" HeaderPointerPressed="DataGridPacketLossColumn_HeaderPointerPressed">
+							    <DataGridTemplateColumn.CellTemplate>
+							        <DataTemplate>
+							            <TextBlock 
+                                            Text="{Binding PacketLoss}"
+                                            Foreground="{Binding PacketLoss, Converter={StaticResource PacketLossColorConverter}}"
+                                            VerticalAlignment="Center"
+                                            Padding="12,0,0,0"/>
+							        </DataTemplate>
+							    </DataGridTemplateColumn.CellTemplate>
+							</DataGridTemplateColumn>
 							<DataGridTextColumn Width="100" Header="Status" Binding="{Binding Status}" />
-                        </DataGrid.Columns>
+						</DataGrid.Columns>
+
 						<DataGrid.Styles>
                             <Style Selector="DataGridColumnHeader">
                                 <Setter Property="FontWeight" Value="Bold"/>
@@ -236,8 +244,8 @@
                           Margin="8,0,0,0">
                           <Button x:Name="BlockAllBtn"
                               Classes="main-btn"
-                              Command="{Binding BlockAllAsync}"
                               IsEnabled="{Binding IsOperationAllowed}"
+                              Command="{Binding BlockAllAsync}"
                               VerticalAlignment="Center"
                               MaxWidth="200"
                               ToolTip.Tip="{DynamicResource BlockAll}"
@@ -250,8 +258,8 @@
                           <Button 
                               x:Name="BlockSelectedBtn" 
                               Classes="main-btn" 
-                              Command="{Binding BlockSelectedAsync}"
                               IsEnabled="{Binding IsOperationAllowed}"
+                              Command="{Binding BlockSelectedAsync}"
                               CommandParameter="{Binding ElementName=ServerList, Path=SelectedItems}"
                               VerticalAlignment="Center"
                               MaxWidth="200"
@@ -271,9 +279,9 @@
                           Margin="0,0,8,0">
                           <Button 
                               x:Name="UnlockAllBtn" 
-                              Classes="main-btn" 
-                              Command="{Binding UnblockAllAsync}"
+                              Classes="main-btn"
                               IsEnabled="{Binding IsOperationAllowed}"
+                              Command="{Binding UnblockAllAsync}"
                               VerticalAlignment="Center"
                               MinWidth="100"
                               MaxWidth="200"
@@ -286,9 +294,9 @@
                           </Button>
                           <Button 
                               x:Name="UnblockSelectedBtn" 
-                              Classes="main-btn" 
-                              Command="{Binding UnblockSelectedAsync}"
+                              Classes="main-btn"
                               IsEnabled="{Binding IsOperationAllowed}"
+                              Command="{Binding UnblockSelectedAsync}"
                               CommandParameter="{Binding ElementName=ServerList, Path=SelectedItems}"
                               VerticalAlignment="Center"
                               MinWidth="100"

--- a/ServerPickerX/Views/MainWindow.axaml
+++ b/ServerPickerX/Views/MainWindow.axaml
@@ -14,6 +14,7 @@
         Width="920"
         Height="640"
         Icon="/Assets/favicon.ico"
+        WindowDecorations="BorderOnly"
         ExtendClientAreaToDecorationsHint="True"
         ExtendClientAreaTitleBarHeightHint="-1"
         WindowStartupLocation="CenterScreen"
@@ -44,6 +45,10 @@
                     Width="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Width}"
                     IsIndeterminate="True"
                     IsVisible="{Binding ShowProgressBar}"/>
+                <TextBlock VerticalAlignment="Center" Margin="10,0,0,0" Foreground="White" FontWeight="Bold" FontSize="14">
+                    Server Picker X
+                </TextBlock>
+                <userControls:TitleBarButtons/>
             </Grid>
 
             <!-- Main Content -->

--- a/ServerPickerX/Views/MainWindow.axaml.cs
+++ b/ServerPickerX/Views/MainWindow.axaml.cs
@@ -37,6 +37,7 @@ namespace ServerPickerX.Views
         }
 
         private ListSortDirection pingSortDirection = ListSortDirection.Ascending;
+        private ListSortDirection packetLossSortDirection = ListSortDirection.Ascending;
         private bool _suppressPresetSelectionChanged;
         private PresetModel? _previousPreset;
 
@@ -133,15 +134,6 @@ namespace ServerPickerX.Views
             e.Handled = true;
             var parentWindow = TopLevel.GetTopLevel(this) as Window;
             parentWindow?.BeginMoveDrag(e);
-        }
-
-        private void DataGridTextColumn_HeaderPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
-        {
-            pingSortDirection = pingSortDirection == ListSortDirection.Ascending
-                ? ListSortDirection.Descending
-                : ListSortDirection.Ascending;
-
-            ServerList.Columns[3].CustomSortComparer = new PingComparer(pingSortDirection);
         }
 
         private async void ClusterUnclusterBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -281,7 +273,8 @@ namespace ServerPickerX.Views
                     MsBox.Avalonia.Enums.Icon.Setting
                     );
 
-            bool unblocked = await vm.UnblockCurrentGameServersAsync();
+            // Unblock current game rules while preserving last selected preset
+            bool unblocked = await vm.UnblockAllAsync(shouldClearLastSelectedPreset: false);
 
             if (!unblocked)
             {
@@ -324,8 +317,8 @@ namespace ServerPickerX.Views
                 return;
             }
 
-            // Clear the currently loaded game's rules before changing game mode
-            await vm.UnblockCurrentGameServersAsync();
+            // Clear the currently loaded game rules before changing game mode while preserving last selected preset
+            await vm.UnblockAllAsync(shouldClearLastSelectedPreset: false);
 
             // Update json setting game mode and serialize it
             await _jsonSetting.SetGameModeAsync((string)GameModeComboBox.SelectedItem);
@@ -383,6 +376,24 @@ namespace ServerPickerX.Views
             ClusterUnclusterBtn.Content = _localizationService.GetLocaleValue(
                 _jsonSetting.is_clustered ? "UnclusterServers" : "ClusterServers"
                 );
+        }
+
+        private void DataGridPingColumn_HeaderPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
+        {
+            pingSortDirection = pingSortDirection == ListSortDirection.Ascending
+                ? ListSortDirection.Descending
+                : ListSortDirection.Ascending;
+
+            ServerList.Columns[3].CustomSortComparer = new PingComparer(pingSortDirection);
+        }
+
+        private void DataGridPacketLossColumn_HeaderPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
+        {
+            packetLossSortDirection = packetLossSortDirection == ListSortDirection.Ascending
+                ? ListSortDirection.Descending
+                : ListSortDirection.Ascending;
+
+            ServerList.Columns[4].CustomSortComparer = new PacketLossComparer(packetLossSortDirection);
         }
     }
 }

--- a/ServerPickerX/Views/UserControls/FooterButtons.axaml.cs
+++ b/ServerPickerX/Views/UserControls/FooterButtons.axaml.cs
@@ -20,14 +20,14 @@ public partial class FooterButtons : UserControl
 
     private async void PaypalBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-await ServiceLocator
+        await ServiceLocator
             .GetRequiredService<IProcessService>()
             .OpenUrl("https://www.paypal.com/paypalme/fnfal113");
     }
 
     private async void GithubBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-await ServiceLocator
+        await ServiceLocator
             .GetRequiredService<IProcessService>()
             .OpenUrl("https://github.com/FN-FAL113/server-picker-x");
     }

--- a/ServerPickerX/Views/UserControls/TitleBarButtons.axaml
+++ b/ServerPickerX/Views/UserControls/TitleBarButtons.axaml
@@ -12,8 +12,13 @@
             Classes="titlebar-btn minimize-btn"
             Width="32"
             Height="32"
-            BorderThickness="0"
             Click="MinimizeBtn_Click" />
+        <Button
+            Name="MaximizeBtn"
+            Classes="titlebar-btn maximize-btn"
+            Width="32"
+            Height="32"
+            Click="MaximizeBtn_Click" />
         <Button
             Name="CloseBtn"
             Classes="titlebar-btn close-btn"

--- a/ServerPickerX/Views/UserControls/TitleBarButtons.axaml
+++ b/ServerPickerX/Views/UserControls/TitleBarButtons.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="https://github.com/projektanker/icons.avalonia"
              mc:Ignorable="d" 
              x:Class="ServerPickerX.TitleBarButtons">
     <StackPanel
@@ -10,18 +11,22 @@
         <Button
             Name="MinimizeBtn"
             Classes="titlebar-btn minimize-btn"
+            i:Attached.Icon="mdi-window-minimize" 
             Width="32"
             Height="32"
             Click="MinimizeBtn_Click" />
         <Button
             Name="MaximizeBtn"
             Classes="titlebar-btn maximize-btn"
+            i:Attached.Icon="mdi-window-maximize" 
             Width="32"
             Height="32"
             Click="MaximizeBtn_Click" />
         <Button
             Name="CloseBtn"
             Classes="titlebar-btn close-btn"
+            i:Attached.Icon="mdi-window-close" 
+            FontSize="18"
             Width="32"
             Height="32"
             Click="CloseBtn_Click" />

--- a/ServerPickerX/Views/UserControls/TitleBarButtons.axaml.cs
+++ b/ServerPickerX/Views/UserControls/TitleBarButtons.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using ServerPickerX.Services.DependencyInjection;
+using ServerPickerX.Services.MessageBoxes;
 
 namespace ServerPickerX;
 
@@ -23,5 +25,23 @@ public partial class TitleBarButtons : UserControl
         var parentWindow = TopLevel.GetTopLevel(this) as Window;
 
         parentWindow?.Close();
+    }
+
+    private void MaximizeBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var parentWindow = TopLevel.GetTopLevel(this) as Window;
+        
+        if (parentWindow?.Name == "Settings")
+        {
+            return;
+        }
+
+        if (parentWindow?.WindowState == WindowState.Maximized) 
+        {
+            parentWindow?.WindowState = WindowState.Normal;
+        } else
+        {
+            parentWindow?.WindowState = WindowState.Maximized;
+        }
     }
 }

--- a/ServerPickerX/Views/UserWindows/PresetManagerWindow.axaml
+++ b/ServerPickerX/Views/UserWindows/PresetManagerWindow.axaml
@@ -6,18 +6,13 @@
         xmlns:viewmodels="using:ServerPickerX.ViewModels"
         xmlns:converters="clr-namespace:ServerPickerX.Converters"
         mc:Ignorable="d"
-
+        Title="{Binding WindowTitle}"
+        FontWeight="SemiBold"
         Width="996"
-        MinWidth="996"
-        MaxWidth="1280"
         Height="610"
-        MinHeight="500"
-        MaxHeight="960"
         x:Class="ServerPickerX.Views.PresetManagerWindow"
         x:DataType="viewmodels:PresetManagerWindowViewModel"
-        SystemDecorations="BorderOnly"
         ExtendClientAreaToDecorationsHint="True"
-        ExtendClientAreaChromeHints="NoChrome"
         ExtendClientAreaTitleBarHeightHint="-1"
         WindowStartupLocation="CenterOwner"
         Background="Transparent">
@@ -26,43 +21,10 @@
         <converters:ImageConverter x:Key="ImageConverter" />
     </Window.Resources>
 
-    <Window.Styles>
-        <Style Selector="DataGrid.preset-grid">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Foreground" Value="White" />
-            <Setter Property="CanUserResizeColumns" Value="False" />
-            <Setter Property="CanUserReorderColumns" Value="False" />
-            <Setter Property="CanUserSortColumns" Value="False" />
-            <Setter Property="GridLinesVisibility" Value="All" />
-            <Setter Property="HeadersVisibility" Value="Column" />
-        </Style>
-        <Style Selector="DataGrid.preset-grid DataGridColumnHeader">
-            <Setter Property="Background" Value="#1A1D40" />
-            <Setter Property="Foreground" Value="White" />
-            <Setter Property="FontWeight" Value="SemiBold" />
-        </Style>
-        <Style Selector="DataGrid.preset-grid DataGridCell">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Foreground" Value="White" />
-        </Style>
-        <Style Selector="DataGrid.preset-grid TextBox">
-            <Setter Property="Background" Value="#1A1D40" />
-            <Setter Property="Foreground" Value="White" />
-            <Setter Property="BorderBrush" Value="#00d9ff" />
-            <Setter Property="CaretBrush" Value="White" />
-            <Setter Property="SelectionBrush" Value="#575cd4" />
-        </Style>
-        <Style Selector="CheckBox.preset-toggle">
-            <Setter Property="Foreground" Value="White" />
-            <Setter Property="HorizontalAlignment" Value="Center" />
-            <Setter Property="VerticalAlignment" Value="Center" />
-        </Style>
-    </Window.Styles>
-
     <Border
         Background="#373B78"
         BorderBrush="#575cd4"
-        BorderThickness="1.35">
+        BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="30" />
@@ -72,14 +34,6 @@
             <Grid x:Name="TitleBar"
                   Background="#373B78"
                   PointerPressed="TitleBar_PointerPressed">
-                <TextBlock
-                    VerticalAlignment="Center"
-                    Margin="10,0,0,0"
-                    Foreground="White"
-                    FontWeight="Bold"
-                    FontSize="14"
-                    Text="{Binding WindowTitle}" />
-                <userControls:TitleBarButtons />
             </Grid>
 
             <Grid Grid.Row="1" Margin="8,8,8,8">

--- a/ServerPickerX/Views/UserWindows/PresetManagerWindow.axaml
+++ b/ServerPickerX/Views/UserWindows/PresetManagerWindow.axaml
@@ -6,12 +6,12 @@
         xmlns:viewmodels="using:ServerPickerX.ViewModels"
         xmlns:converters="clr-namespace:ServerPickerX.Converters"
         mc:Ignorable="d"
-        Title="{Binding WindowTitle}"
+        x:Class="ServerPickerX.Views.PresetManagerWindow"
+        x:DataType="viewmodels:PresetManagerWindowViewModel"
         FontWeight="SemiBold"
         Width="996"
         Height="610"
-        x:Class="ServerPickerX.Views.PresetManagerWindow"
-        x:DataType="viewmodels:PresetManagerWindowViewModel"
+        WindowDecorations="BorderOnly"
         ExtendClientAreaToDecorationsHint="True"
         ExtendClientAreaTitleBarHeightHint="-1"
         WindowStartupLocation="CenterOwner"
@@ -34,6 +34,14 @@
             <Grid x:Name="TitleBar"
                   Background="#373B78"
                   PointerPressed="TitleBar_PointerPressed">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Margin="10,0,0,0"
+                    Foreground="White"
+                    FontWeight="Bold"
+                    FontSize="14"
+                    Text="{Binding WindowTitle}" />
+                <userControls:TitleBarButtons />
             </Grid>
 
             <Grid Grid.Row="1" Margin="8,8,8,8">

--- a/ServerPickerX/Views/UserWindows/SettingsWindow.axaml
+++ b/ServerPickerX/Views/UserWindows/SettingsWindow.axaml
@@ -10,9 +10,9 @@
     Height="250"
     x:Class="ServerPickerX.SettingsWindow"
     x:DataType="viewmodels:SettingsWindowViewModel"
-    SystemDecorations="BorderOnly"
+    Title="Settings"
+    FontWeight="SemiBold"
     ExtendClientAreaToDecorationsHint="True"
-    ExtendClientAreaChromeHints="NoChrome"
     ExtendClientAreaTitleBarHeightHint="-1"
     WindowStartupLocation="CenterOwner"
     CanResize="False"
@@ -38,7 +38,7 @@
         Classes="wBorder" 
         Background="#373B78"
         BorderBrush="#575cd4"
-        BorderThickness="1.35">
+        BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <!-- Title Bar -->
@@ -51,15 +51,6 @@
             <Grid x:Name="TitleBar" 
                   Background="#373B78" 
                   PointerPressed="TitleBar_PointerPressed">
-                <TextBlock 
-                    VerticalAlignment="Center" 
-                    Margin="10,0,0,0" 
-                    Foreground="White" 
-                    FontWeight="Bold" 
-                    FontSize="14">
-                    Settings
-                </TextBlock>
-                <userControls:TitleBarButtons/>
             </Grid>
 
             <!-- Main Content -->

--- a/ServerPickerX/Views/UserWindows/SettingsWindow.axaml
+++ b/ServerPickerX/Views/UserWindows/SettingsWindow.axaml
@@ -6,12 +6,14 @@
     xmlns:constants="clr-namespace:ServerPickerX.Constants"
     xmlns:viewmodels="using:ServerPickerX.ViewModels"
     mc:Ignorable="d"
-    Width="400"
-    Height="250"
     x:Class="ServerPickerX.SettingsWindow"
     x:DataType="viewmodels:SettingsWindowViewModel"
+    x:Name="Settings"
+    Width="400"
+    Height="250"
     Title="Settings"
     FontWeight="SemiBold"
+    WindowDecorations="BorderOnly"
     ExtendClientAreaToDecorationsHint="True"
     ExtendClientAreaTitleBarHeightHint="-1"
     WindowStartupLocation="CenterOwner"
@@ -51,6 +53,15 @@
             <Grid x:Name="TitleBar" 
                   Background="#373B78" 
                   PointerPressed="TitleBar_PointerPressed">
+                <TextBlock 
+                    VerticalAlignment="Center" 
+                    Margin="10,0,0,0" 
+                    Foreground="White" 
+                    FontWeight="Bold" 
+                    FontSize="14">
+                    Settings
+                </TextBlock>
+                <userControls:TitleBarButtons/>
             </Grid>
 
             <!-- Main Content -->


### PR DESCRIPTION
## Changes
- Introduce packet-loss metrics, colored ping/packet-loss displays, additional sorting, and relay probing logic.
- Dedicated DataGrid style and include it in App.axaml.
- ServerModel.PingServer was refactored to select the best relay, probe it multiple times, and populate Ping, PacketLoss and Status accordingly.
- MainWindow updated to show colored Ping and Packet Loss template columns, wire header click handlers to custom comparers, and adjust various UI/layout properties.
- MainViewModel code chores
- Tweak resource helper to support loading resources like images in avalonia design previewer by updating assembly name condition.
- Remove obsolete Avalonia data-annotation removal helper and simplify window chrome/title bar code in several user windows.
- Allow maximizing main window by removing min/max width/height
- Upgrade AvaloniaUI to latest v12 build and related packages
- Switch fontawesome icon package to another fork that supports avalonia v12
- Bump assembly version to 1.1.0

Resolves #33 and #39 